### PR TITLE
fix: Add --load to docker buildx build command

### DIFF
--- a/build-container-image/action.yml
+++ b/build-container-image/action.yml
@@ -93,9 +93,16 @@ runs:
         IMAGE_MANIFEST_URI="${IMAGE_REPOSITORY_URI}:${IMAGE_MANIFEST_TAG}"
         echo "IMAGE_MANIFEST_URI=${IMAGE_MANIFEST_URI}" | tee -a $GITHUB_OUTPUT
 
+        echo "::group::docker buildx build"
         # TODO (@NickLarsenNZ): Allow optional buildx cache
         docker buildx build \
         --file "${CONTAINER_FILE}" \
         --platform "linux/${IMAGE_ARCH}" \
         --tag "${IMAGE_MANIFEST_URI}" \
+        --load \
         "${BUILD_CONTEXT}"
+        echo "::endgroup::"
+
+        echo "::group::docker images"
+        docker images
+        echo "::endgroup::"


### PR DESCRIPTION
- Add `--load` option to `docker buildx build`
  Otherwise `docker push` doesn't work in later steps.
- Add log groupings to reduce noise