### PR TITLE
fix: make PURLs use oci type / fixed SBOM component name

### DIFF
--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -122,7 +122,7 @@ runs:
           exit 1
         fi
         # Construct the package url (purl)
-        PURL="pkg:oci/{$SOURCE_NAME}@{$URLENCODED_DIGEST}?arch=${ARCH}&repository_url=${REGISTRY_URI}%2F${URLENCODED_IMAGE_REPOSITORY}"
+        PURL="pkg:oci/${SOURCE_NAME}@${URLENCODED_DIGEST}?arch=${ARCH}&repository_url=${REGISTRY_URI}%2F${URLENCODED_IMAGE_REPOSITORY}"
 
         # Get metadata from the image
         # NOTE (@Techassi): Maybe we should run this command only once

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -126,8 +126,8 @@ runs:
 
         # Get metadata from the image
         # NOTE (@Techassi): Maybe we should run this command only once
-        IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "${IMAGE_REPO_DIGEST}")
-        IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "${IMAGE_REPO_DIGEST}")
+        IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_REPO_DIGEST")
+        IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_REPO_DIGEST")
 
         # Generate the SBOM
         syft scan \
@@ -135,7 +135,7 @@ runs:
           --select-catalogers "-cargo-auditable-binary-cataloger,+sbom-cataloger" \
           --scope all-layers \
           --source-name "$SOURCE_NAME" \
-          --source-version "$IMAGE_MANIFEST_TAG" "${IMAGE_REPO_DIGEST}"
+          --source-version "$IMAGE_MANIFEST_TAG" "$IMAGE_REPO_DIGEST"
 
         # Merge SBOM components using https://github.com/stackabletech/mergebom
         curl --fail -L -o mergebom https://repo.stackable.tech/repository/packages/mergebom/stable-$(uname -m)

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -128,7 +128,7 @@ runs:
           --output cyclonedx-json@1.5=sbom_raw.json \
           --select-catalogers "-cargo-auditable-binary-cataloger,+sbom-cataloger" \
           --scope all-layers \
-          --source-name "$IMAGE_REPOSITORY" \
+          --source-name "$IMAGE_NAME" \
           --source-version "$IMAGE_MANIFEST_TAG" "${IMAGE_REPO_DIGEST}"
 
         # Merge SBOM components using https://github.com/stackabletech/mergebom

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -110,8 +110,8 @@ runs:
         DIGEST=${IMAGE_REPO_DIGEST#*@}
 
         # URL encode the digest and image repository, needed for the purl
-        URLENCODED_DIGEST=$(echo "$DIGEST" | jq -Rr @uri)
-        URLENCODED_IMAGE_REPOSITORY=$(echo "$IMAGE_REPOSITORY" | jq -Rr @uri)
+        URLENCODED_DIGEST=$(jq -rn --arg input "$DIGEST" '$input | @uri')
+        URLENCODED_IMAGE_REPOSITORY=$(jq -rn --arg input "$IMAGE_REPOSITORY" '$input | @uri')
         # Last item, split by /
         # Example: sdp/kafka -> kafka
         SOURCE_NAME=$(echo "$IMAGE_REPOSITORY" | awk -F'/' '{print $NF}')
@@ -122,7 +122,7 @@ runs:
           exit 1
         fi
         # Construct the package url (purl)
-        PURL="pkg:oci/$SOURCE_NAME@$URLENCODED_DIGEST?arch=${ARCH}&repository_url=${REGISTRY_URI}%2F${URLENCODED_IMAGE_REPOSITORY}"
+        PURL="pkg:oci/{$SOURCE_NAME}@{$URLENCODED_DIGEST}?arch=${ARCH}&repository_url=${REGISTRY_URI}%2F${URLENCODED_IMAGE_REPOSITORY}"
 
         # Get metadata from the image
         # NOTE (@Techassi): Maybe we should run this command only once

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -109,14 +109,20 @@ runs:
         # Extract the digest from the image repo digest (right side of '@')
         DIGEST=${IMAGE_REPO_DIGEST#*@}
 
-        # Construct the package url (purl)
-        URLENCODED_DIGEST=$(echo "$DIGEST" | sed 's/:/%3A/g')
-        URLENCODED_IMAGE_REPOSITORY=$(echo "$IMAGE_REPOSITORY" | sed 's/\//%2F/g')
+        # URL encode the digest and image repository, needed for the purl
+        URLENCODED_DIGEST=$(echo "$DIGEST" | jq -Rr @uri)
+        URLENCODED_IMAGE_REPOSITORY=$(echo "$IMAGE_REPOSITORY" | jq -Rr @uri)
         # Last item, split by /
-        IMAGE_NAME=$(echo "$IMAGE_REPOSITORY" | awk -F'/' '{print $NF}')
-        # Obtain architecture from container image
-        ARCH=$(docker inspect --format='{{index .Architecture}}' "${IMAGE_REPO_DIGEST}")
-        PURL="pkg:oci/$IMAGE_NAME@$URLENCODED_DIGEST?arch=${ARCH}&repository_url=${REGISTRY_URI}%2F${URLENCODED_IMAGE_REPOSITORY}"
+        # Example: sdp/kafka -> kafka
+        SOURCE_NAME=$(echo "$IMAGE_REPOSITORY" | awk -F'/' '{print $NF}')
+        # Extract architecture from image tag
+        ARCH=$(echo "$IMAGE_MANIFEST_TAG" | awk -F'-' '{print $NF}')
+        if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ]; then
+          echo "Invalid architecture obtained from image tag. IMAGE_MANIFEST_TAG: $IMAGE_MANIFEST_TAG, ARCH: $ARCH"
+          exit 1
+        fi
+        # Construct the package url (purl)
+        PURL="pkg:oci/$SOURCE_NAME@$URLENCODED_DIGEST?arch=${ARCH}&repository_url=${REGISTRY_URI}%2F${URLENCODED_IMAGE_REPOSITORY}"
 
         # Get metadata from the image
         # NOTE (@Techassi): Maybe we should run this command only once
@@ -128,7 +134,7 @@ runs:
           --output cyclonedx-json@1.5=sbom_raw.json \
           --select-catalogers "-cargo-auditable-binary-cataloger,+sbom-cataloger" \
           --scope all-layers \
-          --source-name "$IMAGE_NAME" \
+          --source-name "$SOURCE_NAME" \
           --source-version "$IMAGE_MANIFEST_TAG" "${IMAGE_REPO_DIGEST}"
 
         # Merge SBOM components using https://github.com/stackabletech/mergebom

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -110,8 +110,13 @@ runs:
         DIGEST=${IMAGE_REPO_DIGEST#*@}
 
         # Construct the package url (purl)
-        # TODO (@Techassi): Can we use 'oci' instead of 'docker' as the type?
-        PURL="pkg:docker/$IMAGE_REPOSITORY@$DIGEST?repository_url=$REGISTRY_URI"
+        URLENCODED_DIGEST=$(echo "$DIGEST" | sed 's/:/%3A/g')
+        URLENCODED_IMAGE_REPOSITORY=$(echo "$IMAGE_REPOSITORY" | sed 's/\//%2F/g')
+        # Last item, split by /
+        IMAGE_NAME=$(echo "$IMAGE_REPOSITORY" | awk -F'/' '{print $NF}')
+        # Obtain architecture from container image
+        ARCH=$(docker inspect --format='{{index .Architecture}}' "${IMAGE_REPO_DIGEST}")
+        PURL="pkg:oci/$IMAGE_NAME@$URLENCODED_DIGEST?arch=${ARCH}&repository_url=${REGISTRY_URI}%2F${URLENCODED_IMAGE_REPOSITORY}"
 
         # Get metadata from the image
         # NOTE (@Techassi): Maybe we should run this command only once


### PR DESCRIPTION
Same thing as https://github.com/stackabletech/operator-templating/pull/448, but for our product images. It probably makes sense for the same person to review both this PR and the other.

---
Use OCI type for PURLs, according to https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci

This is more correct in general and most importantly makes the PURL equal to the one Trivy generates for our container images.

This PR is a bit more complicated than the one for operators, since I had to extract the product name (e.g. "kafka") and the architecture before generating the PURL.

I also added another small change to this PR:
The `--source-name` passed to Syft is now just the name of the image. Currently, it would be `sdp/kafka`. This change changes it to just `kafka`. The parameter ist reflected in `.metadata.component.name` in the SBOM and I think just `kafka` is the correct value here, it should not include the repository.