### PR TITLE
fix!: Remove free-disk-space from the build-*-image actions

### DIFF
--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -41,11 +41,11 @@ jobs:
           - {name: "ubicloud-standard-8-arm", arch: "arm64"}
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:
-      - name: Free Disk Space
-        uses: ./free-disk-space
-
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Free Disk Space
+        uses: ./free-disk-space
 
       - name: Build Product Container Image
         id: build

--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -41,6 +41,9 @@ jobs:
           - {name: "ubicloud-standard-8-arm", arch: "arm64"}
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:
+      - name: Free Disk Space
+        uses: ./free-disk-space
+
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/build-container-image/action.yml
+++ b/build-container-image/action.yml
@@ -42,9 +42,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Free Disk Space
-      uses: ./free-disk-space
-
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 

--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -29,9 +29,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Free Disk Space
-      uses: ./free-disk-space
-
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 

--- a/free-disk-space/action.yml
+++ b/free-disk-space/action.yml
@@ -1,17 +1,6 @@
 ---
 name: Free Disk Space
 description: This action frees up disk space on a runner.
-inputs:
-  product-name:
-    description: The name of the product to build via bake (directory name)
-    required: true
-  config-file:
-    description: Path the the config file used to generate the shard indices
-    default: ./conf.py
-outputs:
-  versions:
-    description: A list of product versions
-    value: ${{ steps.generate_shards.outputs.VERSIONS }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
There are different paths when running `free-disk-space` directly in actions from this repository (eg: in smoke tests) vs being called from a remote repository.

There doesn't appear to be an easy way to work around it.

## Breaking change

Workflows using the `build-product-image` or `build-container-image` actions will need to run `free-disk-space` explicitly beforehand.

Eg:

```yml
    steps:
      # 👇
      - name: Free Disk Space
        uses: stackabletech/actions/free-disk-space@x.x.x
      # ☝️

      - name: Checkout Repository
        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

      - name: Build Product Image
        id: build
        uses: stackabletech/actions/build-product-image@x.x.x
        with:
          product-name: ${{ env.PRODUCT_NAME }}
          product-version: ${{ matrix.versions }}
          build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}

```