### PR TITLE
chore: Bump action versions

### DIFF
--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -19,7 +19,7 @@ jobs:
     name: Generate Version List
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: shard
         uses: ./shard
         with:
@@ -42,7 +42,7 @@ jobs:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Free Disk Space
         uses: ./free-disk-space
@@ -77,7 +77,7 @@ jobs:
         versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
         uses: ./publish-index-manifest

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           submodules: recursive

--- a/build-container-image/action.yml
+++ b/build-container-image/action.yml
@@ -43,7 +43,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
     # TODO (@NickLarsenNZ): Allow optional buildx cache
     #   # Needed if you pass the --cache argument to the bake command below

--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       # NOTE (@Techassi): Why do we install python via apt and not the setup-python action?
     - name: Setup Python

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -46,10 +46,10 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
     - name: Set up syft
-      uses: anchore/sbom-action/download-syft@61119d458adab75f756bc0b9e4bde25725f86a7a # v0.17.2
+      uses: anchore/sbom-action/download-syft@55dc4ee22412511ee8c3142cbea40418e6cec693 # v0.17.8
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/publish-index-manifest/action.yml
+++ b/publish-index-manifest/action.yml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/run-integration-test/action.yml
+++ b/run-integration-test/action.yml
@@ -99,7 +99,7 @@ runs:
     - name: Prepare Replicated Cluster
       if: env.KUBERNETES_DISTRIBUTION != 'ionos'
       id: prepare-replicated-cluster
-      uses: replicatedhq/replicated-actions/create-cluster@v1 # todo, hash
+      uses: replicatedhq/replicated-actions/create-cluster@77121785951d05387334b773644c356885191f14 # v1.16.2
       with:
         # See: https://github.com/replicatedhq/replicated-actions/tree/main/create-cluster#inputs
         api-token: ${{ inputs.replicated-api-token }}
@@ -210,7 +210,7 @@ runs:
       if: env.KUBERNETES_DISTRIBUTION != 'ionos' && always()
       # If the creation of the cluster failed, we don't want to error and abort
       continue-on-error: true
-      uses: replicatedhq/replicated-actions/remove-cluster@v1 # todo, hash
+      uses: replicatedhq/replicated-actions/remove-cluster@77121785951d05387334b773644c356885191f14 # v1.16.2
       with:
         # See: https://github.com/replicatedhq/replicated-actions/tree/main/remove-cluster#inputs
         api-token: ${{ inputs.replicated-api-token }}

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -21,12 +21,12 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Setup Rust Toolchain
-      uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a
+      uses: dtolnay/rust-toolchain@315e265cd78dad1e1dcf3a5074f6d6c47029d5aa
       if: ${{ inputs.rust }}
       with:
         toolchain: ${{ inputs.rust }}

--- a/shard/action.yml
+++ b/shard/action.yml
@@ -15,7 +15,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+    - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: '3.12'
 

--- a/smoke/Dockerfile
+++ b/smoke/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine
+FROM alpine@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
 
 RUN echo "I'm a smoke test coming from https://github.com/stackabletech/actions"


### PR DESCRIPTION
This bumps upstream action versions to the latest available version:

- actions/checkout
- actions/setup-python
- docker/setup-buildx-action
- sigstore/cosign-installer
- anchore/sbom-action/download-syft
- replicatedhq/replicated-actions/create-cluster
- replicatedhq/replicated-actions/remove-cluster
- dtolnay/rust-toolchain

It additionally pins the version of the alpine image used for the smoke-test Dockerfile.