### PR TITLE
feat(run-pre-commit): Add support to install nix

### DIFF
--- a/run-pre-commit/README.md
+++ b/run-pre-commit/README.md
@@ -2,11 +2,12 @@
 
 > Manifest: [run-pre-commit/action.yml][run-pre-commit]
 
-This action runs pre-commit by setting up Python and optionally the Rust toolchain and Hadolint in
-the requested version. It requires a checkout with depth 0. It does the following work:
+This action runs pre-commit by setting up Python and optionally installing the Rust toolchain,
+Hadolint, and Nix in the requested version. It requires a checkout with depth 0. It does the
+following work:
 
 1. Installs Python. The version can be configured via the `python-version` input.
-2. Optionally sets up the Rust toolchain and Hadolint.
+2. Optionally sets up the Rust toolchain, Hadolint, and Nix.
 3. Runs pre-commit on changed files.
 
 Example usage (workflow):
@@ -40,6 +41,8 @@ jobs:
 - `rust` (eg: `1.80.1`. Disabled if not specified)
 - `rust-components` (defaults to `rustfmt,clippy`)
 - `hadolint` (eg: `v2.12.0`. Disabled if not specified)
+- `nix` (eg: `2.25.2`. Disabled if not specified)
+- `nix-github-token` (eg: `secrets.GITHUB_TOKEN`. Required when `nix` is set)
 
 ### Outputs
 

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -56,7 +56,7 @@ runs:
 
         echo "$LOCATION_DIR" | tee -a "$GITHUB_PATH"
 
-    - name: Abort nix-github-token input is unset
+    - name: Abort if nix-github-token input is not set
       if: inputs.nix && !inputs.nix-github-token
       shell: bash
       run: |

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -57,7 +57,7 @@ runs:
         echo "$LOCATION_DIR" | tee -a "$GITHUB_PATH"
 
     - name: Abort nix-github-token input is unset
-      if: ${{ inputs.nix }} && !${{ inputs.nix-github-token }}
+      if: ${{ inputs.nix && !inputs.nix-github-token }}
       shell: bash
       run: |
         echo "nix-github-token input must be set when nix input is set"

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: Whether to install hadolint (and which version to use)
   nix:
     description: Whether to install nix (and which version to use)
+  nix-github-token:
+    description: |
+      The GitHub token is used by Nix to pull from GitHub with higher rate-limits. Required when
+      the 'nix' input is used.
 runs:
   using: composite
   steps:
@@ -52,11 +56,18 @@ runs:
 
         echo "$LOCATION_DIR" | tee -a "$GITHUB_PATH"
 
+    - name: Abort nix-github-token input is unset
+      if: ${{ inputs.nix }} && !${{ inputs.nix-github-token }}
+      shell: bash
+      run: |
+        echo "nix-github-token input must be set when nix input is set"
+        exit 1
+
     - name: Setup nix
       if: ${{ inputs.nix }}
       uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 #v30
       with:
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        github_access_token: ${{ inputs.nix-github-token }}
         install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix }}/install
 
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -64,7 +64,7 @@ runs:
         exit 1
 
     - name: Setup nix
-      if: ${{ inputs.nix }}
+      if: inputs.nix
       uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 #v30
       with:
         github_access_token: ${{ inputs.nix-github-token }}

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -17,6 +17,8 @@ inputs:
     default: rustfmt,clippy
   hadolint:
     description: Whether to install hadolint (and which version to use)
+  nix:
+    description: Whether to install nix (and which version to use)
 runs:
   using: composite
   steps:
@@ -49,6 +51,13 @@ runs:
         chmod 700 "${LOCATION_BIN}"
 
         echo "$LOCATION_DIR" | tee -a "$GITHUB_PATH"
+
+    - name: Setup nix
+      if: ${{ inputs.nix }}
+      uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 #v30
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix }}/install
 
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       with:

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -57,7 +57,7 @@ runs:
         echo "$LOCATION_DIR" | tee -a "$GITHUB_PATH"
 
     - name: Abort nix-github-token input is unset
-      if: ${{ inputs.nix && !inputs.nix-github-token }}
+      if: inputs.nix && !inputs.nix-github-token
       shell: bash
       run: |
         echo "nix-github-token input must be set when nix input is set"


### PR DESCRIPTION
This adds support to install nix when running pre-commit. This is useful for repositories which have pre-commit hooks requiring nix to run them.