### PR TITLE
feat(run-integration-test): Add k3s and RKE2 cluster mappings

### DIFF
--- a/run-integration-test/README.md
+++ b/run-integration-test/README.md
@@ -4,10 +4,24 @@
 
 This action runs an operator integration test. It does the following work:
 
-1. Create a test cluster on-the-fly using the requested Kubernetes version and distribution via
-   Replicated.
+1. Create a test cluster on-the-fly using the requested Kubernetes version, distribution and node
+   architecture via Replicated. See [Test Platform Triple](#test-platform-triple) for more details.
 2. Run the integration test based on the provided test parameters.
 3. Delete the cluster of the tests are done and send out a notification on failure.
+
+## Test Platform Triple
+
+The [`test-platform`](#inputs) input expects a test platform triple to select the appropriate node
+architecture and kubernetes distribution & version. The triple format is
+`<DISTRIBUTION>-<VERSION>-<ARCHITECTURE>`, eg. `kind-1.31.2-amd64` or `gke-1.31-arm64`.
+
+Each distribution supports different instance types
+(based on the cloud vendor machine names). This mapping is done via the `instances.yml` file. Based
+on this file, the following distributions are supported: `eks`, `gke`, `aks`, `kind`, `k3s`, `rke2`.
+There is no mapping for `oke` yet.
+
+Supported Kubernetes version can be inspected on the official Replicated documentation
+[page][supported-clusters]. Supported architectures are `amd64` and `arm64`.
 
 ## Inputs and Outputs
 
@@ -16,7 +30,7 @@ This action runs an operator integration test. It does the following work:
 
 ### Inputs
 
-- `test-platform`(required, eg: `kind-1.31.0-amd64`)
+- `test-platform`(required, eg: `kind-1.31.2-amd64`)
 - `test-run` (required, `test-suite` or `test`)
 - `test-parameter` (defaults to `smoke`)
 - `replicated-api-token` (required)
@@ -26,4 +40,5 @@ This action runs an operator integration test. It does the following work:
 - `start-time`
 - `end-time`
 
+[supported-clusters]: https://docs.replicated.com/vendor/testing-supported-clusters
 [run-integration-test]: ./action.yml

--- a/run-integration-test/README.md
+++ b/run-integration-test/README.md
@@ -12,11 +12,11 @@ This action runs an operator integration test. It does the following work:
 ## Test Platform Triple
 
 The [`test-platform`](#inputs) input expects a test platform triple to select the appropriate node
-architecture and kubernetes distribution & version. The triple format is
+architecture and Kubernetes distribution & version. The triple format is
 `<DISTRIBUTION>-<VERSION>-<ARCHITECTURE>`, eg. `kind-1.31.2-amd64` or `gke-1.31-arm64`.
 
 Each distribution supports different instance types
-(based on the cloud vendor machine names). This mapping is done via the `instances.yml` file. Based
+based on the cloud vendor machine names. This mapping is done via the `instances.yml` file. Based
 on this file, the following distributions are supported: `eks`, `gke`, `aks`, `kind`, `k3s`, `rke2`.
 There is no mapping for `oke` yet.
 

--- a/run-integration-test/instances.yml
+++ b/run-integration-test/instances.yml
@@ -1,3 +1,8 @@
+########################
+# Cloud based clusters #
+########################
+
+# https://docs.replicated.com/vendor/testing-supported-clusters#eks
 eks:
   arm64:
     small: m7g.large
@@ -8,6 +13,7 @@ eks:
     medium: m6i.2xlarge
     large: m6i.4xlarge
 
+# https://docs.replicated.com/vendor/testing-supported-clusters#gke
 gke:
   arm64:
     small: t2a-standard-2
@@ -18,6 +24,7 @@ gke:
     medium: e2-standard-8
     large: e2-standard-16
 
+# https://docs.replicated.com/vendor/testing-supported-clusters#aks
 aks:
   arm64:
     small: Standard_D2ps_v5
@@ -28,7 +35,26 @@ aks:
     medium: Standard_DS3_v2
     large: Standard_DS5_v2
 
+##################################
+# VM based clusters (only AMD64) #
+##################################
+
+# https://docs.replicated.com/vendor/testing-supported-clusters#kind
 kind:
+  amd64:
+    small: r1.small
+    medium: r1.medium
+    large: r1.large
+
+# https://docs.replicated.com/vendor/testing-supported-clusters#k3s
+k3s:
+  amd64:
+    small: r1.small
+    medium: r1.medium
+    large: r1.large
+
+# https://docs.replicated.com/vendor/testing-supported-clusters#rke2-beta
+rke2:
   amd64:
     small: r1.small
     medium: r1.medium


### PR DESCRIPTION
This PR adds mappings for k3s and RKE2 clusters, which both support nodes > 1 (kind on Replicated only supports single node clusters).