### PR TITLE
feat(build-product-image): Add extra-tag-data input

### DIFF
--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -55,6 +55,7 @@ jobs:
           product-version: ${{ matrix.versions }}
           build-cache-password: ${{ secrets.BUILD_CACHE_NEXUS_PASSWORD }}
           bake-config-file: smoke/conf.py
+          extra-tag-data: pr-321
 
       - name: Publish Container Image on oci.stackable.tech
         uses: ./publish-image

--- a/build-product-image/README.md
+++ b/build-product-image/README.md
@@ -48,6 +48,7 @@ localhost/kafka:3.4.1-stackable0.0.0-dev-amd64
 - `build-cache-password` (required) <!-- TODO: make the cache optional -->
 - `bake-config-file` (defaults to `./conf.py`)
 - `sdp-version` (defaults to: `0.0.0-dev`)
+- `extra-tag-data` (optional, eg. `pr321`)
 
 ### Outputs
 

--- a/build-product-image/README.md
+++ b/build-product-image/README.md
@@ -53,5 +53,6 @@ localhost/kafka:3.4.1-stackable0.0.0-dev-amd64
 ### Outputs
 
 - `image-manifest-tag` (eg: `3.4.1-stackable0.0.0-dev-amd64`)
+- `suggested-image-index-manifest-tag` (eg: `3.4.1-stackable0.0.0-dev`)
 
 [build-product-image]: ./action.yml

--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -24,6 +24,9 @@ inputs:
     description: |
       Stackable Data Platform version (eg: `24.7.0`)
     default: 0.0.0-dev
+  extra-tag-data:
+    description: |
+      Extra data to include in the final image manifest tag (eg: `pr321`)
 outputs:
   image-manifest-tag:
     description: |
@@ -61,16 +64,22 @@ runs:
         BAKE_PRODUCT_VERSION: ${{ inputs.product-version }}
         BAKE_CONFIG_FILE: ${{ inputs.bake-config-file }}
         IMAGE_REPOSITORY: ${{ inputs.product-name }}
+        EXTRA_TAG_DATA: ${{ inputs.extra-tag-data }}
         SDP_VERSION: ${{ inputs.sdp-version }}
       shell: bash
       run: |
         set -euo pipefail
         IMAGE_ARCH=$("$GITHUB_ACTION_PATH/../.scripts/get_architecture.sh")
 
+        # Will be either:
+        # - 3.9.2-stackable0.0.0-dev-arm64 or
+        # - 3.9.2-stackable0.0.0-dev-pr321-arm64
+        IMAGE_VERSION="${SDP_VERSION}${EXTRA_TAG_DATA:+-$EXTRA_TAG_DATA}-${IMAGE_ARCH}"
+
         echo "::group::bake"
         bake \
           --product "$IMAGE_REPOSITORY=$BAKE_PRODUCT_VERSION" \
-          --image-version "${SDP_VERSION}-${IMAGE_ARCH}" \
+          --image-version "$IMAGE_VERSION" \
           --architecture "linux/${IMAGE_ARCH}" \
           --export-tags-file bake-target-tags \
           --configuration "$BAKE_CONFIG_FILE" \

--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -76,6 +76,13 @@ runs:
         # - 3.9.2-stackable0.0.0-dev-pr321-arm64
         IMAGE_VERSION="${SDP_VERSION}${EXTRA_TAG_DATA:+-$EXTRA_TAG_DATA}-${IMAGE_ARCH}"
 
+        # Validate that final tag is valid according to
+        # https://github.com/distribution/reference/blob/8c942b0459dfdcc5b6685581dd0a5a470f615bff/regexp.go#L68
+        if ! echo "$IMAGE_VERSION" | grep --perl-regexp --quiet '^[\w][\w.-]{1,127}$'; then
+          >&2 echo "Encountered invalid image manifest tag: $IMAGE_VERSION"
+          exit 1
+        fi
+
         echo "::group::bake"
         bake \
           --product "$IMAGE_REPOSITORY=$BAKE_PRODUCT_VERSION" \

--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -33,6 +33,11 @@ outputs:
       Human-readable tag (usually the version) with architecture information,
       for example: `3.4.1-stackable0.0.0-dev-amd64`
     value: ${{ steps.image_info.outputs.IMAGE_MANIFEST_TAG }}
+  suggested-image-index-manifest-tag:
+    description: |
+      Human-readable tag (usually the version) without architecture information,
+      for example: `3.4.1-stackable0.0.0-dev`
+    value: ${{ steps.image_info.outputs.IMAGE_INDEX_MANIFEST_TAG }}
 runs:
   using: composite
   steps:
@@ -74,19 +79,20 @@ runs:
         # Will be either:
         # - 3.9.2-stackable0.0.0-dev-arm64 or
         # - 3.9.2-stackable0.0.0-dev-pr321-arm64
-        IMAGE_VERSION="${SDP_VERSION}${EXTRA_TAG_DATA:+-$EXTRA_TAG_DATA}-${IMAGE_ARCH}"
+        IMAGE_INDEX_MANIFEST_TAG="${SDP_VERSION}${EXTRA_TAG_DATA:+-$EXTRA_TAG_DATA}-${IMAGE_ARCH}"
+        echo "IMAGE_INDEX_MANIFEST_TAG=$IMAGE_INDEX_MANIFEST_TAG" | tee -a "$GITHUB_ENV"
 
         # Validate that final tag is valid according to
         # https://github.com/distribution/reference/blob/8c942b0459dfdcc5b6685581dd0a5a470f615bff/regexp.go#L68
-        if ! echo "$IMAGE_VERSION" | grep --perl-regexp --quiet '^[\w][\w.-]{1,127}$'; then
-          >&2 echo "Encountered invalid image manifest tag: $IMAGE_VERSION"
+        if ! echo "$IMAGE_INDEX_MANIFEST_TAG" | grep --perl-regexp --quiet '^[\w][\w.-]{1,127}$'; then
+          >&2 echo "Encountered invalid image manifest tag: $IMAGE_INDEX_MANIFEST_TAG"
           exit 1
         fi
 
         echo "::group::bake"
         bake \
           --product "$IMAGE_REPOSITORY=$BAKE_PRODUCT_VERSION" \
-          --image-version "$IMAGE_VERSION" \
+          --image-version "$IMAGE_INDEX_MANIFEST_TAG" \
           --architecture "linux/${IMAGE_ARCH}" \
           --export-tags-file bake-target-tags \
           --configuration "$BAKE_CONFIG_FILE" \
@@ -118,7 +124,9 @@ runs:
         # Extract the image manifest tag from the bake-target-tags file
         IMAGE_MANIFEST_TAG=$(cut -d : -f 2 < bake-target-tags)
         [[ -n "$IMAGE_MANIFEST_TAG" ]]
+        [[ -n "$IMAGE_INDEX_MANIFEST_TAG" ]]
 
         # Add the contents of the env variables to the GitHub output, so that it
         # can be used as action outputs
         echo "IMAGE_MANIFEST_TAG=$IMAGE_MANIFEST_TAG" | tee -a "$GITHUB_OUTPUT"
+        echo "IMAGE_INDEX_MANIFEST_TAG=$IMAGE_INDEX_MANIFEST_TAG" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/pull/948

Changes for the `build-product-image` action:
- Add a `extra-tag-data` input to allow extra tag data in the image manifest tag, like PR numbers: `3.9.2-stackable0.0.0-dev-pr321-arm64`.
- Add a `suggested-image-index-manifest-tag` output for subsequent jobs to make use of.