### PR TITLE
feat(interu): Add --check-test-options flag

### DIFF
--- a/tools/interu/fixtures/interu.yaml
+++ b/tools/interu/fixtures/interu.yaml
@@ -6,7 +6,7 @@ runners:
       - name: default
         arch: amd64
         size: large
-        disk: 50
+        disk-gb: 50
         nodes: 3
 
   default-arm64:
@@ -16,7 +16,7 @@ runners:
       - name: default
         arch: arm64
         size: large
-        disk: 50
+        disk-gb: 50
         nodes: 3
 
   default-mixed:
@@ -26,12 +26,12 @@ runners:
       - name: amd64-nodes
         arch: amd64
         size: large
-        disk: 50
+        disk-gb: 50
         nodes: 3
       - name: arm64-nodes
         arch: arm64
         size: large
-        disk: 50
+        disk-gb: 50
         nodes: 3
 
 profiles:

--- a/tools/interu/src/cli.rs
+++ b/tools/interu/src/cli.rs
@@ -23,8 +23,7 @@ pub struct Cli {
         option,
         short = 'o',
         long = "output",
-        description = "write configuration key=value pairs separated by newlines to file
-    Useful for CI tools which give a file to write env vars and outputs to which are used in subsequent steps"
+        description = "write configuration key=value pairs separated by newlines to file. Useful for CI tools which give a file to write env vars and outputs to which are used in subsequent steps"
     )]
     pub output: Option<PathBuf>,
 
@@ -32,6 +31,10 @@ pub struct Cli {
     // #[arg(short, long, visible_short_alias('s'), visible_alias("silent"))]
     #[argh(switch, short = 'q', long = "quiet")]
     pub quiet: bool,
+
+    /// validate the test options of the selected profile
+    #[argh(switch, long = "check-test-options")]
+    pub check_test_options: bool,
 
     /// which test profile to use
     #[argh(positional)]

--- a/tools/interu/src/config/mod.rs
+++ b/tools/interu/src/config/mod.rs
@@ -11,7 +11,7 @@ use tracing::instrument;
 
 use crate::{
     config::{
-        profile::{Profile, StrategyValidationError, TestRun},
+        profile::{Profile, StrategyValidationError, TestOptions, TestRun},
         runner::{
             ConvertNodeGroupError, Distribution, ReplicatedNodeGroup, Runner, RunnerValidationError,
         },
@@ -21,6 +21,7 @@ use crate::{
 
 pub mod profile;
 pub mod runner;
+pub mod tests;
 
 /// Errors which can be encountered when reading and validating the config file.
 #[derive(Debug, Snafu)]
@@ -42,6 +43,9 @@ pub enum Error {
         source: ValidationError,
         path: PathBuf,
     },
+
+    #[snafu(display("failed to validate test options"))]
+    ValidateTestOptions { source: StrategyValidationError },
 
     #[snafu(display("failed to find profile named {profile_name:?}"))]
     UnknownProfileName { profile_name: String },
@@ -92,25 +96,16 @@ impl Config {
         Ok(config)
     }
 
-    #[instrument(name = "validate_config", skip(self))]
-    fn validate(&self) -> Result<(), ValidationError> {
-        for (runner_name, runner) in &self.runners {
-            tracing::debug!(runner_name, "validate runner");
+    pub fn get_profile(&self, profile_name: &String) -> Result<&Profile, Error> {
+        self.profiles
+            .get(profile_name)
+            .context(UnknownProfileNameSnafu { profile_name })
+    }
 
-            runner
-                .validate(runner_name)
-                .context(InvalidRunnerConfigSnafu)?;
-        }
-
-        for (profile_name, profile) in &self.profiles {
-            tracing::debug!(profile_name, "validate profile");
-
-            profile
-                .validate(profile_name, &self.runners)
-                .context(InvalidProfileConfigSnafu)?;
-        }
-
-        Ok(())
+    pub fn validate_test_options(&self, profile_name: &String) -> Result<(), Error> {
+        self.get_profile(profile_name)?
+            .validate_test_options(&profile_name)
+            .context(ValidateTestOptionsSnafu)
     }
 
     /// Determines the final expanded parameters based on the provided profile.
@@ -120,10 +115,7 @@ impl Config {
         instances: &'a Instances,
     ) -> Result<Parameters<'a>, Error> {
         // First, lookup the profile by name. Error if the profile does't exist.
-        let profile = self
-            .profiles
-            .get(profile_name)
-            .context(UnknownProfileNameSnafu { profile_name })?;
+        let profile = self.get_profile(profile_name)?;
 
         // Next, lookup the runner ref based on the profile strategy
         let runner_ref = match &profile.strategy {
@@ -144,7 +136,11 @@ impl Config {
         let runner = self.runners.get(runner_ref).unwrap();
 
         // Get test options
-        let (test_parallelism, test_run, test_parameter) = profile.strategy.get_test_options();
+        let TestOptions {
+            parallelism,
+            test_run,
+            test_parameter,
+        } = profile.strategy.get_test_options();
 
         // Convert our node groups to replicated node groups
         let node_groups = runner
@@ -158,12 +154,33 @@ impl Config {
         Ok(Parameters {
             kubernetes_distribution: &runner.platform.distribution,
             kubernetes_version: &runner.platform.version,
+            test_parallelism: *parallelism,
             cluster_ttl: &runner.ttl,
-            test_parallelism,
             test_parameter,
             node_groups,
             test_run,
         })
+    }
+
+    #[instrument(name = "validate_config", skip(self))]
+    fn validate(&self) -> Result<(), ValidationError> {
+        for (runner_name, runner) in &self.runners {
+            tracing::debug!(runner_name, "validate runner");
+
+            runner
+                .validate(runner_name)
+                .context(InvalidRunnerConfigSnafu)?;
+        }
+
+        for (profile_name, profile) in &self.profiles {
+            tracing::debug!(profile_name, "validate profile");
+
+            profile
+                .validate(profile_name, &self.runners)
+                .context(InvalidProfileConfigSnafu)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/tools/interu/src/config/tests.rs
+++ b/tools/interu/src/config/tests.rs
@@ -1,0 +1,59 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use snafu::{ResultExt as _, Snafu};
+use tracing::instrument;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("failed to read test definition file at {path}", path = path.display()))]
+    ReadFile {
+        source: std::io::Error,
+        path: PathBuf,
+    },
+
+    #[snafu(display("failed to deserialize test definition file at {path} as yaml", path = path.display()))]
+    Deserialize {
+        source: serde_yaml::Error,
+        path: PathBuf,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TestDefinition {
+    #[serde(default)]
+    pub tests: Vec<Test>,
+
+    #[serde(default)]
+    pub suites: Vec<Suite>,
+}
+
+impl TestDefinition {
+    /// Read and deserialize test definition from a file located at `path`.
+    #[instrument(name = "load_test_definition_from_file", skip(path), fields(path = %path.as_ref().display()))]
+    pub fn from_file<P>(path: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
+        let contents = std::fs::read_to_string(&path).context(ReadFileSnafu {
+            path: path.as_ref(),
+        })?;
+
+        tracing::debug!("deserialize file contents");
+        let test_definition: Self = serde_yaml::from_str(&contents).context(DeserializeSnafu {
+            path: path.as_ref(),
+        })?;
+
+        Ok(test_definition)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Test {
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Suite {
+    pub name: String,
+}

--- a/tools/interu/src/main.rs
+++ b/tools/interu/src/main.rs
@@ -13,6 +13,9 @@ enum Error {
     #[snafu(display("failed to load config"))]
     LoadConfig { source: config::Error },
 
+    #[snafu(display("failed to validate test options"))]
+    ValidateTestOptions { source: config::Error },
+
     #[snafu(display("failed to determine expanded parameters"))]
     DetermineParameters { source: config::Error },
 
@@ -31,6 +34,12 @@ fn main() -> Result<(), Error> {
     tracing::info!("load config and instance mappings file");
     let config = Config::from_file(&cli.config).context(LoadConfigSnafu)?;
     let instances = Instances::from_file(&cli.instances).context(LoadInstancesSnafu)?;
+
+    if cli.check_test_options {
+        config
+            .validate_test_options(&cli.profile)
+            .context(ValidateTestOptionsSnafu)?;
+    }
 
     tracing::info!("determine parameters");
     let parameters = config


### PR DESCRIPTION
This adds the `--check-test-options` flag which validates that the test or test-suite is defined in the `tests/test-definition.yaml` file.