### PR TITLE
ci: Add missing needs key

### DIFF
--- a/.github/workflows/release_interu.yml
+++ b/.github/workflows/release_interu.yml
@@ -21,6 +21,7 @@ jobs:
             os: ubuntu-latest
   release:
     runs-on: ubuntu-latest
+    needs: [build]
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8


### PR DESCRIPTION
The `release` job needs to run _after_ the build job.