### PR TITLE
ci: Bump broken action

### DIFF
--- a/.github/workflows/build_interu.yml
+++ b/.github/workflows/build_interu.yml
@@ -32,10 +32,14 @@ jobs:
           targets: ${{ inputs.target }}
 
       - name: Build Binary
-        run: cargo build --target ${{ inputs.target }} --release --package interu
+        env:
+          TARGET: ${{ inputs.target }}
+        run: cargo build --target "$TARGET" --release --package interu
 
       - name: Rename Binary
-        run: mv target/${{ inputs.target }}/release/interu interu-${{ inputs.target }}
+        env:
+          TARGET: ${{ inputs.target }}
+        run: mv "target/$TARGET/release/interu" "interu-$TARGET"
 
       - name: Upload Artifact
         if: inputs.upload

--- a/.github/workflows/release_interu.yml
+++ b/.github/workflows/release_interu.yml
@@ -29,6 +29,6 @@ jobs:
           path: artifacts
 
       - name: Upload Release Binary
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           files: artifacts/artifact/*


### PR DESCRIPTION
The `softprops/action-gh-release` had a broken file upload in version `2.2.0`. The issue was fixed in `2.2.1`.

See https://github.com/softprops/action-gh-release/pull/562