### PR TITLE
chore: update to oci references

### DIFF
--- a/.scripts/get_manifest_digest.sh
+++ b/.scripts/get_manifest_digest.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Get a manifest digest. Example inputs:
-# - docker.stackable.tech/stackable/hello-world:0.0.1-SNAPSHOT-stackable0.0.0-dev
-# - docker.stackable.tech/stackable/hello-world:0.0.1-SNAPSHOT-stackable0.0.0-dev-amd64
+# - oci.stackable.tech/sdp/hello-world:0.0.1-SNAPSHOT-stackable0.0.0-dev
+# - oci.stackable.tech/sdp/hello-world:0.0.1-SNAPSHOT-stackable0.0.0-dev-amd64
 set -euo pipefail
 
 # Note: `docker manifest push` currently outputs the same hash, but `manifest`

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ particular step in a workflow.
 
 | Name                               | Example                                                                |
 | ---------------------------------- | ---------------------------------------------------------------------- |
-| Image Registry                     | `docker.stackable.tech`                                                |
+| Image Registry                     | `oci.stackable.tech`                                                |
 | Image Repository                   | `stackable/kafka`                                                      |
 | Image Index Manifest Tag           | `3.4.1-stackable0.0.0-dev`                                             |
 | Image Manifest Tag                 | `3.4.1-stackable0.0.0-dev-amd64`                                       |
-| Image Repository URI               | `docker.stackable.tech/stackable/kafka`                                |
-| Image Index URI (if multi-arch)    | `docker.stackable.tech/stackable/kafka:3.4.1-stackable0.0.0-dev`       |
-| Image Manifest URI (if multi-arch) | `docker.stackable.tech/stackable/kafka:3.4.1-stackable0.0.0-dev-amd64` |
-| Image Repo Digest                  | `docker.stackable.tech/stackable/kafka@sha256:917f800259ef4915f976...` |
+| Image Repository URI               | `oci.stackable.tech/sdp/kafka`                                |
+| Image Index URI (if multi-arch)    | `oci.stackable.tech/sdp/kafka:3.4.1-stackable0.0.0-dev`       |
+| Image Manifest URI (if multi-arch) | `oci.stackable.tech/sdp/kafka:3.4.1-stackable0.0.0-dev-amd64` |
+| Image Repo Digest                  | `oci.stackable.tech/sdp/kafka@sha256:917f800259ef4915f976...` |
 | Digest                             | `sha256:917f800259ef4915f976e93987b752fd64debf347568610d7f685d2022...` |
 
 ## Available Actions

--- a/build-product-image/README.md
+++ b/build-product-image/README.md
@@ -16,7 +16,7 @@ This action builds a *single* container image using `bake`. It does the followin
 
 1. Free disk space to avoid running out of disk space during larger builds.
 2. Build the image using `bake` which internally uses `docker buildx`.
-3. Temporarily retag the image to use `localhost` instead of `docker.stackable.tech/stackable`.
+3. Temporarily retag the image to use `localhost` instead of `oci.stackable.tech/sdp`.
 4. Produce output values to be used in later steps.
 
 This action is considered to be the **single** source of truth regarding image index tag and image
@@ -25,7 +25,7 @@ manifest tag. All subsequent tasks must use these values to ensure consistency.
 Currently, bake provides the following ouput in the `bake-target-tags` file:
 
 ```plain
-docker.stackable.tech/stackable/kafka:3.4.1-stackable0.0.0-dev-amd64
+oci.stackable.tech/sdp/kafka:3.4.1-stackable0.0.0-dev-amd64
 ```
 
 Until bake supports the ability to specify the registry, this action will retag the image as:
@@ -43,7 +43,7 @@ localhost/kafka:3.4.1-stackable0.0.0-dev-amd64
 
 - `product-name` (eg: `kafka`)
 - `product-version` (eg: `3.4.1`)
-- `image-tools-version` (eg: `0.0.13`)
+- `image-tools-version` (eg: `0.0.14`)
 - `bake-config-file` (defaults to `./conf.py`)
 - `sdp-version` (defaults to: `0.0.0-dev`)
 - `extra-tag-data` (optional, eg. `pr321`)

--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   image-tools-version:
     description: The Stackable image-tools version
-    default: 0.0.13
+    default: 0.0.14
   bake-config-file:
     description: Path to the bake config file, defaults to `./conf.py`
     default: ./conf.py
@@ -89,12 +89,12 @@ runs:
       run: |
         set -euo pipefail
 
-        # Extract the image uri and replace 'docker.stackable.tech/stackable'
+        # Extract the image uri and replace 'oci.stackable.tech/sdp'
         # with 'localhost' until bake does the right thing
         OLD_IMAGE_URI="$(< bake-target-tags)"
 
         # Replace the image uri in the bake file
-        sed -i -e 's/docker\.stackable\.tech\/stackable/localhost/' bake-target-tags
+        sed -i -e 's/oci\.stackable\.tech\/sdp/localhost/' bake-target-tags
 
         # Finally, re-tag image
         docker tag "$OLD_IMAGE_URI" "$(< bake-target-tags)"

--- a/publish-index-manifest/action.yml
+++ b/publish-index-manifest/action.yml
@@ -60,7 +60,7 @@ runs:
         set -euo pipefail
 
         # Construct the image index uri, which for example contains:
-        # docker.stackable.tech/stackable/kafka:3.4.1-stackable0.0.0-dev
+        # oci.stackable.tech/sdp/kafka:3.4.1-stackable0.0.0-dev
         IMAGE_INDEX_URI="$REGISTRY_URI/$IMAGE_REPOSITORY:$IMAGE_INDEX_MANIFEST_TAG"
         echo "IMAGE_INDEX_URI=$IMAGE_INDEX_URI" | tee -a "$GITHUB_ENV"
 
@@ -100,7 +100,7 @@ runs:
         DIGEST=$("$GITHUB_ACTION_PATH/../.scripts/get_manifest_digest.sh" "$IMAGE_INDEX_URI")
 
         # Construct the image repo digest, which for example contains:
-        # docker.stackable.tech/stackable/kafka@sha256:91...
+        # oci.stackable.tech/sdp/kafka@sha256:91...
         IMAGE_REPO_DIGEST="$REGISTRY_URI/$IMAGE_REPOSITORY@$DIGEST"
 
         # This generates a signature and publishes it to the registry, next to

--- a/tools/interu/fixtures/test-definition.yaml
+++ b/tools/interu/fixtures/test-definition.yaml
@@ -7,12 +7,12 @@ dimensions:
       - 2.9.3
       - 2.10.2
       # To use a custom image, add a comma and the full name after the product version
-      # - 2.8.1,docker.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
+      # - 2.8.1,oci.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
   - name: airflow-latest
     values:
       - 2.10.2
       # To use a custom image, add a comma and the full name after the product version
-      # - 2.8.1,docker.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
+      # - 2.8.1,oci.stackable.tech/sandbox/airflow:2.8.1-stackable0.0.0-dev
   - name: ldap-authentication
     values:
       - no-tls


### PR DESCRIPTION
Part of https://github.com/stackabletech/infrastructure/issues/142
Updates registry references to oci. Uses new image-tools version containing oci reference changes.