### PR TITLE
feat(run-pre-commit): Enable caching, support pre-commit pinning

### DIFF
--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -30,6 +30,7 @@ runs:
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ inputs.python-version }}
+        cache: 'pip'
 
     - name: Setup Rust Toolchain
       uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -33,6 +33,14 @@ runs:
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ inputs.python-version }}
+        # It doesn't make a whole lot of sense to use the pre-commit config file
+        # as the dependency file, but the setup-python action looks for
+        # requirements.txt and pyproject.toml by default, which are both not
+        # present (in most cases). To override these two defaults, we need to
+        # specify a different file. Specifying the pre-commit config at least
+        # guarantees that the cache is invalidated if the config changes.
+        # Ideally we want to invalidate when the pre-commit or Python version
+        # changes, but that's not easily possible.
         cache-dependency-path: .pre-commit-config.yaml
         cache: 'pip'
 

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -51,9 +51,17 @@ runs:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ inputs.pre-commit-version }}-python${{ inputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
+    - name: Setup Rust Toolchain Cache
+      id: rust-toolchain-cache
+      if: ${{ inputs.rust }}
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.rustup/toolchains
+        key: rust-toolchains-${{ inputs.rust }}-components-${{ inputs.rust-components }}
+
     - name: Setup Rust Toolchain
       uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
-      if: ${{ inputs.rust }}
+      if: ${{ inputs.rust && steps.rust-toolchain-cache.outputs.cache-hit != 'true' }}
       with:
         toolchain: ${{ inputs.rust }}
         components: ${{ inputs.rust-components }}

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -8,6 +8,9 @@ inputs:
   python-version:
     description: Python version to install
     default: "3.12"
+  pre-commit-version:
+    description: Pre-commit version to install
+    default: 4.2.0
   rust:
     description: Whether to install the Rust toolchain (and which version to use)
   rust-components:
@@ -32,6 +35,21 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache-dependency-path: .pre-commit-config.yaml
         cache: 'pip'
+
+    - name: Install pre-commit (${{ env.PRE_COMMIT_VERSION }})
+      shell: bash
+      env:
+        PRE_COMMIT_VERSION: ${{ inputs.pre-commit-version }}
+      run: |
+        python -m pip install "pre-commit==$PRE_COMMIT_VERSION"
+
+      # This caches downloaded pre-commit hook artifacts and results in faster
+      # workflow runs after an initial hydration run with the exact same hooks
+    - name: Setup pre-commit Cache
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ inputs.pre-commit-version }}-python${{ inputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Setup Rust Toolchain
       uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
@@ -72,6 +90,10 @@ runs:
         github_access_token: ${{ inputs.nix-github-token }}
         install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix }}/install
 
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-      with:
-        extra_args: "--from-ref '${{ github.event.pull_request.base.sha }}' --to-ref '${{ github.event.pull_request.head.sha }}'"
+    - name: Run pre-commit
+      shell: bash
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        pre-commit run --show-diff-on-failure --color always --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA"

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -66,9 +66,11 @@ runs:
         toolchain: ${{ inputs.rust }}
         components: ${{ inputs.rust-components }}
 
-    - name: Setup Hadolint
+    - name: Install Hadolint
       if: ${{ inputs.hadolint }}
       shell: bash
+      env:
+        HADOLINT_VERSION: ${{ inputs.hadolint }}
       run: |
         set -euo pipefail
 
@@ -79,8 +81,8 @@ runs:
         ARCH=$(uname -m)
 
         mkdir -p "$LOCATION_DIR"
-        curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ inputs.hadolint }}/hadolint-$SYSTEM-$ARCH"
-        chmod 700 "${LOCATION_BIN}"
+        curl -sL -o "$LOCATION_BIN" "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-$SYSTEM-$ARCH"
+        chmod 700 "$LOCATION_BIN"
 
         echo "$LOCATION_DIR" | tee -a "$GITHUB_PATH"
 

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -30,6 +30,7 @@ runs:
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ inputs.python-version }}
+        cache-dependency-path: .pre-commit-config.yaml
         cache: 'pip'
 
     - name: Setup Rust Toolchain

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -59,13 +59,22 @@ runs:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ inputs.pre-commit-version }}-python${{ inputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
+    - name: Format Rust Toolchain Cache Key
+      if: ${{ inputs.rust }}
+      shell: bash
+      env:
+        RUST_COMPONENTS: ${{ inputs.rust-components }}
+      run: |
+        RUST_COMPONENTS=${RUST_COMPONENTS//,/_}
+        echo "RUST_COMPONENTS=$RUST_COMPONENTS" | tee -a "$GITHUB_ENV"
+
     - name: Setup Rust Toolchain Cache
       id: rust-toolchain-cache
       if: ${{ inputs.rust }}
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.rustup/toolchains
-        key: rust-toolchains-${{ inputs.rust }}-components-${{ inputs.rust-components }}
+        key: rust-toolchains-${{ inputs.rust }}-components-${{ env.RUST_COMPONENTS }}
 
     - name: Setup Rust Toolchain
       uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c


### PR DESCRIPTION
This PR enables caching for:

- **pip:** Reduces time from 49s to 12s (in this repo), which is a 75% decrease in time
- **rust:** Hard to measure individually, but it roughly went from 10s to 3s (in this repo), which is a 70% decrease in time

Very simple testing in https://github.com/stackabletech/operator-rs/pull/1014 showed a reduction from 1m2s to 23s, which is roughly a 62% speedup (for run 1+n).

---

It also enables pinning pre-commit to a specific version. Before, the action always installed the latest available version.