### PR TITLE
chore: Bump various actions to latest version

### DIFF
--- a/build-container-image/action.yml
+++ b/build-container-image/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
     - name: Build ${{ inputs.image-name }}:${{ inputs.image-index-manifest-tag }}
       id: build-image

--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       # NOTE (@Techassi): Why do we install python via apt and not the setup-python action?
     - name: Setup Python

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -52,7 +52,7 @@ runs:
       uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: ${{ inputs.image-registry-uri }}
         username: ${{ inputs.image-registry-username }}

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -46,7 +46,7 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+      uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
     - name: Set up syft
       uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0

--- a/publish-index-manifest/action.yml
+++ b/publish-index-manifest/action.yml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+      uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/publish-index-manifest/action.yml
+++ b/publish-index-manifest/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: ${{ inputs.image-registry-uri }}
         username: ${{ inputs.image-registry-username }}

--- a/run-integration-test/action.yml
+++ b/run-integration-test/action.yml
@@ -106,7 +106,7 @@ runs:
     - name: Prepare Replicated Cluster
       if: env.KUBERNETES_DISTRIBUTION != 'ionos'
       id: prepare-replicated-cluster
-      uses: replicatedhq/replicated-actions/create-cluster@c98ab3b97925af5db9faf3f9676df7a9c6736985 # v1.17.0
+      uses: replicatedhq/replicated-actions/create-cluster@49b440dabd7e0e868cbbabda5cfc0d8332a279fa # v1.19.0
       with:
         # See: https://github.com/replicatedhq/replicated-actions/tree/main/create-cluster#inputs
         api-token: ${{ inputs.replicated-api-token }}
@@ -216,7 +216,7 @@ runs:
       if: env.KUBERNETES_DISTRIBUTION != 'ionos' && always()
       # If the creation of the cluster failed, we don't want to error and abort
       continue-on-error: true
-      uses: replicatedhq/replicated-actions/remove-cluster@c98ab3b97925af5db9faf3f9676df7a9c6736985 # v1.17.0
+      uses: replicatedhq/replicated-actions/remove-cluster@49b440dabd7e0e868cbbabda5cfc0d8332a279fa # v1.19.0
       with:
         # See: https://github.com/replicatedhq/replicated-actions/tree/main/remove-cluster#inputs
         api-token: ${{ inputs.replicated-api-token }}

--- a/run-integration-test/action.yml
+++ b/run-integration-test/action.yml
@@ -14,13 +14,13 @@ inputs:
     default: 0.1.0
   beku-version:
     description: Version of beku
-    default: 0.0.8
+    default: 0.0.10
   kuttl-version:
     description: Version of kubectl-kuttl
-    default: 0.21.0
+    default: 0.22.0
   stackablectl-version:
     description: Version of stackablectl
-    default: 24.11.3
+    default: 25.3.0
 outputs:
   start-time:
     description: The date and time this integration test was started.

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: ${{ inputs.python-version }}
         # It doesn't make a whole lot of sense to use the pre-commit config file

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -77,7 +77,7 @@ runs:
         key: rust-toolchains-${{ inputs.rust }}-components-${{ env.RUST_COMPONENTS }}
 
     - name: Setup Rust Toolchain
-      uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
+      uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
       if: ${{ inputs.rust && steps.rust-toolchain-cache.outputs.cache-hit != 'true' }}
       with:
         toolchain: ${{ inputs.rust }}

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -112,7 +112,7 @@ runs:
 
     - name: Setup nix
       if: inputs.nix
-      uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 #v30
+      uses: cachix/install-nix-action@754537aaedb35f72ab11a60cc162c49ef3016495 #v31.2.0
       with:
         github_access_token: ${{ inputs.nix-github-token }}
         install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix }}/install

--- a/shard/action.yml
+++ b/shard/action.yml
@@ -15,7 +15,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+    - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
This PR bumps various actions used to prepare for a `0.8.0` release of our custom actions:

- docker/setup-buildx-action to 3.10.0
- sigstore/cosign-installer to 3.8.2
- docker/login-action to 3.4.0
- replicatedhq/replicated-actions to 1.19.0
- actions/setup-python to 5.5.0
- dtolnay/rust-toolchain
- cachix/install-nix-action to 31.2.0