### PR TITLE
feat: Add send-slack-notification action

### DIFF
--- a/send-slack-notification/README.md
+++ b/send-slack-notification/README.md
@@ -1,0 +1,1 @@
+# send-slack-notification

--- a/send-slack-notification/README.md
+++ b/send-slack-notification/README.md
@@ -2,7 +2,7 @@
 
 > Manifest: [send-slack-notification/action.yaml][send-slack-notification]
 
-This action sends a slack message to notify about container image build failures and successes.
+This action sends a Slack message to notify about container image build failures and successes.
 Subsequent attempts of the same workflow run are automatically threaded in Slack.
 The color of the message is automatically selected based on the provided results.
 

--- a/send-slack-notification/README.md
+++ b/send-slack-notification/README.md
@@ -1,1 +1,43 @@
-# send-slack-notification
+# `send-slack-notification`
+
+> Manifest: [send-slack-notification/action.yaml][send-slack-notification]
+
+This action sends a slack message to notify about container image build failures and successes.
+Subsequent attempts of the same workflow run are automatically threaded in Slack.
+The color of the message is automatically selected based on the provided results.
+
+Example usage (workflow):
+
+```yaml
+jobs:
+  notify:
+    name: Failure Notification
+    needs: [job_1, job_2]
+    runs-on: ubuntu-latest
+    if: failure() || github.run_attempt > 1
+    steps:
+      - name: Send Notification
+        uses: stackabletech/actions/send-slack-notification
+        with:
+          build-result: ${{ needs.job_2.result }}
+          publish-manifests-result: ${{ needs.job_2.result }}
+          slack-token: ${{ secrets.MY_SECRET }}
+```
+
+## Inputs and Outputs
+
+> [!TIP]
+> For descriptions of the inputs and outputs, see the complete [send-slack-notification] action.
+
+### Inputs
+
+- `channel-id` (defaults to `C07UG6JH44F`)
+- `build-result` (required, e.g. `success`)
+- `publish-manifests-result` (required, e.g. `failure`)
+- `slack-token` (required)
+
+### Outputs
+
+None
+
+[send-slack-notification]: ./action.yaml

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -1,0 +1,67 @@
+---
+name: Send Failure Notification via Slack
+description: ""
+inputs:
+  channel-id:
+    description: The channel to sent the message to
+    default: C07UG6JH44F # notifications-container-images
+  build-result:
+    description: The result of the build job
+  publish-manifests-result:
+    description: The result of the publish manifests job
+  slack-token:
+    description: The Slack token
+runs:
+  using: composite
+  steps:
+    - name: Retrieve Slack Thread ID
+      if: ${{ github.run_attempt > 1 }}
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      with:
+        name: slack-thread-id-${{ github.run_id }}
+
+    - name: Output Slack Thread ID
+      id: slack-thread-id
+      if: ${{ github.run_attempt > 1 }}
+      shell: bash
+      run: |
+        echo "SLACK_THREAD_ID=$(cat slack-thread-id)" | tee -a "$GITHUB_OUTPUT"
+
+    - name: Send Notification
+      id: send-notification
+      uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # 2.1.0
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.slack-token }}
+        payload: |
+          channel: ${{ inputs.channel-id }}
+          text: *${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})
+          ${{ github.run_attempt > 1 && format("thread_ts: {0}", steps.slack-thread-id.outputs.SLACK_THREAD_ID) }}
+          attachments:
+            - pretext: See the details below for a summary of which job(s) failed.
+              color: #aa0000
+              fields:
+                - title: Build/Publish Image
+                  short: true
+                  value: ${{ inputs.build-result }}
+                - title: Build/Publish Manifests
+                  short: true
+                  value: ${{ inputs.publish-manifests-result }}
+              actions:
+                - type: button
+                  text: Go to workflow run
+                  url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+
+    - name: Save Slack Thread ID to File
+      env:
+        SLACK_THREAD_ID: ${{ steps.send-notification.outputs.ts }}
+      shell: bash
+      run: |
+        echo "$SLACK_THREAD_ID" > slack-thread-id
+
+    - name: Store Slack Thread ID as Artifact
+      if: ${{ github.run_attempt == 1 }}
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: slack-thread-id-${{ github.run_id }}
+        path: slack-thread-id

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -36,7 +36,7 @@ runs:
         payload: |
           channel: "${{ inputs.channel-id }}"
           text: "*${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})"
-          ${{ github.run_attempt > 1 && format('thread_ts: {0}', steps.slack-thread-id.outputs.SLACK_THREAD_ID) }}
+          ${{ github.run_attempt > 1 && format('thread_ts: {0}', steps.slack-thread-id.outputs.SLACK_THREAD_ID) || '' }}
           attachments:
             - pretext: See the details below for a summary of which job(s) failed.
               color: "#aa0000"

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -34,23 +34,23 @@ runs:
         method: chat.postMessage
         token: ${{ inputs.slack-token }}
         payload: |
-          channel: ${{ inputs.channel-id }}
+          channel: "${{ inputs.channel-id }}"
           text: "*${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})"
           ${{ github.run_attempt > 1 && format('thread_ts: {0}', steps.slack-thread-id.outputs.SLACK_THREAD_ID) }}
           attachments:
             - pretext: See the details below for a summary of which job(s) failed.
-              color: #aa0000
+              color: "#aa0000"
               fields:
                 - title: Build/Publish Image
                   short: true
-                  value: ${{ inputs.build-result }}
+                  value: "${{ inputs.build-result }}"
                 - title: Build/Publish Manifests
                   short: true
-                  value: ${{ inputs.publish-manifests-result }}
+                  value: "${{ inputs.publish-manifests-result }}"
               actions:
                 - type: button
                   text: Go to workflow run
-                  url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+                  url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
 
     - name: Save Slack Thread ID to File
       env:

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -36,7 +36,7 @@ runs:
         payload: |
           channel: "${{ inputs.channel-id }}"
           text: "*${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})"
-          ${{ github.run_attempt > 1 && format('thread_ts: {0}', steps.slack-thread-id.outputs.SLACK_THREAD_ID) || '' }}
+          ${{ github.run_attempt > 1 && format('thread_ts: "{0}"', steps.slack-thread-id.outputs.SLACK_THREAD_ID) || '' }}
           attachments:
             - pretext: See the details below for a summary of which job(s) failed.
               color: "#aa0000"

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -36,7 +36,7 @@ runs:
         payload: |
           channel: ${{ inputs.channel-id }}
           text: *${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})
-          ${{ github.run_attempt > 1 && format("thread_ts: {0}", steps.slack-thread-id.outputs.SLACK_THREAD_ID) }}
+          ${{ github.run_attempt > 1 && format('thread_ts: {0}', steps.slack-thread-id.outputs.SLACK_THREAD_ID) }}
           attachments:
             - pretext: See the details below for a summary of which job(s) failed.
               color: #aa0000

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -35,7 +35,7 @@ runs:
         token: ${{ inputs.slack-token }}
         payload: |
           channel: ${{ inputs.channel-id }}
-          text: *${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})
+          text: "*${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})"
           ${{ github.run_attempt > 1 && format('thread_ts: {0}', steps.slack-thread-id.outputs.SLACK_THREAD_ID) }}
           attachments:
             - pretext: See the details below for a summary of which job(s) failed.


### PR DESCRIPTION
This PR adds a new send-slack-notification action with support for threading. The action will create threads for each individual workflow run. This allows multiple attempts of the same run to be displayed as a thread. This is mainly used in docker-image workflows.