### PR TITLE
feat(send-slack-notification): Send failure and success message

### DIFF
--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -80,10 +80,10 @@ runs:
     - name: Save Slack Thread ID to File
       if: ${{ env.SLACK_THREAD_ID == 'none' }}
       env:
-        SLACK_THREAD_ID: ${{ steps.send-notification.outputs.ts }}
+        SLACK_THREAD_ID_OUTPUT: ${{ steps.send-notification.outputs.ts }}
       shell: bash
       run: |
-        echo "$SLACK_THREAD_ID" > slack-thread-id
+        echo "$SLACK_THREAD_ID_OUTPUT" > slack-thread-id
 
     - name: Store Slack Thread ID as Artifact
       if: ${{ env.SLACK_THREAD_ID == 'none' }}

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -22,15 +22,10 @@ runs:
         name: slack-thread-id-${{ github.run_id }}
 
     - name: Extract Slack Thread ID into Environment Variable
-      env:
-        RETRIEVE_SLACK_THREAD_ID_OUTCOME: ${{ steps.retrieve-slack-thread-id.outcome }}
+      if: steps.retrieve-slack-thread-id.outcome == 'success'
       shell: bash
       run: |
-        if [ "$RETRIEVE_SLACK_THREAD_ID_OUTCOME" = "success" ]; then
-          echo "SLACK_THREAD_ID=$(cat slack-thread-id)" | tee -a "$GITHUB_ENV"
-        else
-          echo "SLACK_THREAD_ID=none" | tee -a "$GITHUB_ENV"
-        fi
+        echo "SLACK_THREAD_ID=$(cat slack-thread-id)" | tee -a "$GITHUB_ENV"
 
     - name: Format message
       env:
@@ -61,7 +56,7 @@ runs:
         payload: |
           channel: "${{ inputs.channel-id }}"
           text: "${{ env.MESSAGE_TEXT }}"
-          ${{ env.SLACK_THREAD_ID != 'none' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+          ${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
           attachments:
             - pretext: "See the details below for a summary of which job(s) ${{ env.MESSAGE_VERB }}."
               color: "${{ env.MESSAGE_COLOR }}"

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -46,6 +46,7 @@ runs:
         else
           MESSAGE_VERB=succeeded
           MESSAGE_COLOR=10c400
+        fi
 
         echo "MESSAGE_TEXT=*$GITHUB_WORKFLOW* $MESSAGE_VERB (attempt $GITHUB_RUN_ATTEMPT)" | tee -a "$GITHUB_ENV"
         echo "MESSAGE_COLOR=$MESSAGE_COLOR" | tee -a "$GITHUB_ENV"

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -61,7 +61,7 @@ runs:
         payload: |
           channel: "${{ inputs.channel-id }}"
           text: "${{ env.MESSAGE_TEXT }}"
-          ${{ github.run_attempt > 1 && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+          ${{ env.SLACK_THREAD_ID != 'none' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
           attachments:
             - pretext: "See the details below for a summary of which job(s) ${{ env.MESSAGE_VERB }}."
               color: "${{ env.MESSAGE_COLOR }}"

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -73,7 +73,7 @@ runs:
                   url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
 
     - name: Save Slack Thread ID to File
-      if: ${{ env.SLACK_THREAD_ID == 'none' }}
+      if: steps.retrieve-slack-thread-id.outcome == 'failure'
       env:
         SLACK_THREAD_ID_OUTPUT: ${{ steps.send-notification.outputs.ts }}
       shell: bash
@@ -81,7 +81,7 @@ runs:
         echo "$SLACK_THREAD_ID_OUTPUT" > slack-thread-id
 
     - name: Store Slack Thread ID as Artifact
-      if: ${{ env.SLACK_THREAD_ID == 'none' }}
+      if: steps.retrieve-slack-thread-id.outcome == 'failure'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: slack-thread-id-${{ github.run_id }}

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -1,5 +1,5 @@
 ---
-name: Send Failure Notification via Slack
+name: Send Notification via Slack
 description: ""
 inputs:
   channel-id:
@@ -32,9 +32,24 @@ runs:
           echo "SLACK_THREAD_ID=none" | tee -a "$GITHUB_ENV"
         fi
 
+    - name: Format message
+      env:
+        PUBLISH_MANIFESTS_RESULT: ${{ inputs.publish-manifests-result }}
+        GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        GITHUB_WORKFLOW: ${{ github.workflow  }}
+        BUILD_RESULT: ${{ inputs.build-result }}
       shell: bash
       run: |
-        echo "SLACK_THREAD_ID=$(cat slack-thread-id)" | tee -a "$GITHUB_OUTPUT"
+        if [ "$PUBLISH_MANIFESTS_RESULT" = "failure" ] || [ "$BUILD_RESULT" = "failure" ]; then
+          MESSAGE_VERB=failed
+          MESSAGE_COLOR=aa0000
+        else
+          MESSAGE_VERB=succeeded
+          MESSAGE_COLOR=10c400
+
+        echo "MESSAGE_TEXT=*$GITHUB_WORKFLOW* $MESSAGE_VERB (attempt $GITHUB_RUN_ATTEMPT)" | tee -a "$GITHUB_ENV"
+        echo "MESSAGE_COLOR=$MESSAGE_COLOR" | tee -a "$GITHUB_ENV"
+        echo "MESSAGE_VERB=$MESSAGE_VERB" | tee -a "$GITHUB_ENV"
 
     - name: Send Notification
       id: send-notification
@@ -44,11 +59,11 @@ runs:
         token: ${{ inputs.slack-token }}
         payload: |
           channel: "${{ inputs.channel-id }}"
-          text: "*${{ github.workflow }}* failed (attempt ${{ github.run_attempt }})"
-          ${{ github.run_attempt > 1 && format('thread_ts: "{0}"', steps.slack-thread-id.outputs.SLACK_THREAD_ID) || '' }}
+          text: "${{ env.MESSAGE_TEXT }}"
+          ${{ github.run_attempt > 1 && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
           attachments:
-            - pretext: See the details below for a summary of which job(s) failed.
-              color: "#aa0000"
+            - pretext: "See the details below for a summary of which job(s) ${{ env.MESSAGE_VERB }}."
+              color: "${{ env.MESSAGE_COLOR }}"
               fields:
                 - title: Build/Publish Image
                   short: true

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -15,14 +15,23 @@ runs:
   using: composite
   steps:
     - name: Retrieve Slack Thread ID
-      if: ${{ github.run_attempt > 1 }}
+      id: retrieve-slack-thread-id
+      continue-on-error: true
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         name: slack-thread-id-${{ github.run_id }}
 
-    - name: Output Slack Thread ID
-      id: slack-thread-id
-      if: ${{ github.run_attempt > 1 }}
+    - name: Extract Slack Thread ID into Environment Variable
+      env:
+        RETRIEVE_SLACK_THREAD_ID_RESULT: ${{ steps.retrieve-slack-thread-id.result }}
+      shell: bash
+      run: |
+        if [ "$RETRIEVE_SLACK_THREAD_ID_RESULT" = "success" ]; then
+          echo "SLACK_THREAD_ID=$(cat slack-thread-id)" | tee -a "$GITHUB_ENV"
+        else
+          echo "SLACK_THREAD_ID=none" | tee -a "$GITHUB_ENV"
+        fi
+
       shell: bash
       run: |
         echo "SLACK_THREAD_ID=$(cat slack-thread-id)" | tee -a "$GITHUB_OUTPUT"
@@ -53,6 +62,7 @@ runs:
                   url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
 
     - name: Save Slack Thread ID to File
+      if: ${{ env.SLACK_THREAD_ID == 'none' }}
       env:
         SLACK_THREAD_ID: ${{ steps.send-notification.outputs.ts }}
       shell: bash
@@ -60,7 +70,7 @@ runs:
         echo "$SLACK_THREAD_ID" > slack-thread-id
 
     - name: Store Slack Thread ID as Artifact
-      if: ${{ github.run_attempt == 1 }}
+      if: ${{ env.SLACK_THREAD_ID == 'none' }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: slack-thread-id-${{ github.run_id }}

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -23,10 +23,10 @@ runs:
 
     - name: Extract Slack Thread ID into Environment Variable
       env:
-        RETRIEVE_SLACK_THREAD_ID_RESULT: ${{ steps.retrieve-slack-thread-id.result }}
+        RETRIEVE_SLACK_THREAD_ID_OUTCOME: ${{ steps.retrieve-slack-thread-id.outcome }}
       shell: bash
       run: |
-        if [ "$RETRIEVE_SLACK_THREAD_ID_RESULT" = "success" ]; then
+        if [ "$RETRIEVE_SLACK_THREAD_ID_OUTCOME" = "success" ]; then
           echo "SLACK_THREAD_ID=$(cat slack-thread-id)" | tee -a "$GITHUB_ENV"
         else
           echo "SLACK_THREAD_ID=none" | tee -a "$GITHUB_ENV"


### PR DESCRIPTION
This PR extends the capabilities of the send-slack-notification action:

- It is now possible to send failure **and success** messages
- The Slack thread ID retrieval is now idempotent