### PR TITLE
feat(run-pre-commit): Support pinning the rustup version

### DIFF
--- a/run-pre-commit/README.md
+++ b/run-pre-commit/README.md
@@ -41,6 +41,7 @@ jobs:
 - `pre-commit-version` (defaults to `4.2.0`)
 - `rust` (eg: `1.80.1`. Disabled if not specified)
 - `rust-components` (defaults to `rustfmt,clippy`)
+- `rustup-version` (defaults to `1.28.1`)
 - `hadolint` (eg: `v2.12.0`. Disabled if not specified)
 - `nix` (eg: `2.25.2`. Disabled if not specified)
 - `nix-github-token` (eg: `secrets.GITHUB_TOKEN`. Required when `nix` is set)

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -18,6 +18,9 @@ inputs:
       Override which Rust components are installed. Only takes effect when Rust
       is installed.
     default: rustfmt,clippy
+  rustup-version:
+    description: Rustup version used when setting up the Rust toolchain(s)
+    default: 1.28.1
   hadolint:
     description: Whether to install hadolint (and which version to use)
   nix:
@@ -79,6 +82,8 @@ runs:
     - name: Setup Rust Toolchain
       uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
       if: ${{ inputs.rust && steps.rust-toolchain-cache.outputs.cache-hit != 'true' }}
+      env:
+        RUSTUP_VERSION: ${{ inputs.rustup-version }}
       with:
         toolchain: ${{ inputs.rust }}
         components: ${{ inputs.rust-components }}


### PR DESCRIPTION
This PR adds support to pin the `rustup` version used by the `run-pre-commit` action. Potential fix for:

- https://github.com/stackabletech/secret-operator/actions/runs/15106916012/job/42457458733
- https://github.com/stackabletech/listener-operator/actions/runs/15107375388/job/42458831480

The version will be templated by operator-templating, see here: _TBD_.