### PR TITLE
feat: separate --release arg to provide SDP version

### DIFF
--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   image-tools-version:
     description: The Stackable image-tools version
-    default: 0.0.16
+    default: 0.0.17
   bake-config-file:
     description: Path to the bake config file, defaults to `./conf.py`
     default: ./conf.py
@@ -79,6 +79,7 @@ runs:
         bake \
           --product "$IMAGE_REPOSITORY=$BAKE_PRODUCT_VERSION" \
           --image-version "$IMAGE_INDEX_MANIFEST_TAG" \
+          --release "$SDP_VERSION" \
           --architecture "linux/${IMAGE_ARCH}" \
           --export-tags-file bake-target-tags \
           --configuration "$BAKE_CONFIG_FILE"


### PR DESCRIPTION
With `image-tools` 0.0.17 we now have a separate argument to provide the SDP version. This is needed because we want to include the architecture in the image tag (`0.0.0-dev-amd64`) but not in the `RELEASE` argument (that one should just be `0.0.0-dev` or `25.7.0`).
Before 0.0.17 the `--image-version` argument was used for both the image tag and the `RELEASE` arg.