### PR TITLE
feat(run-pre-commit): Use verbose pre-commit output

### DIFF
--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -123,4 +123,4 @@ runs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        pre-commit run --show-diff-on-failure --color always --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA"
+        pre-commit run --verbose --show-diff-on-failure --color always --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA"

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -123,4 +123,9 @@ runs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        pre-commit run --verbose --show-diff-on-failure --color always --from-ref "$BASE_SHA" --to-ref "$HEAD_SHA"
+        pre-commit run \
+          --verbose \
+          --show-diff-on-failure \
+          --color always \
+          --from-ref "$BASE_SHA" \
+          --to-ref "$HEAD_SHA"


### PR DESCRIPTION
With the `--verbose` flag pre-commit will print the duration of each hook (among other details). This helps to indicate long-running hooks to potentially apply improvements to speed up hooks.