### PR TITLE
chore: Bump actions to latest versions

### DIFF
--- a/build-container-image/action.yml
+++ b/build-container-image/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
     - name: Build ${{ inputs.image-name }}:${{ inputs.image-index-manifest-tag }}
       id: build-image

--- a/build-product-image/action.yml
+++ b/build-product-image/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       # NOTE (@Techassi): Why do we install python via apt and not the setup-python action?
     - name: Setup Python

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -46,7 +46,7 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+      uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
     - name: Set up syft
       uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0

--- a/publish-image/action.yml
+++ b/publish-image/action.yml
@@ -49,7 +49,7 @@ runs:
       uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
     - name: Set up syft
-      uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+      uses: anchore/sbom-action/download-syft@9246b90769f852b3a8921f330c59e0b3f439d6e9 # v0.20.1
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/publish-index-manifest/action.yml
+++ b/publish-index-manifest/action.yml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+      uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -77,7 +77,7 @@ runs:
         key: rust-toolchains-${{ inputs.rust }}-components-${{ env.RUST_COMPONENTS }}
 
     - name: Setup Rust Toolchain
-      uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
       if: ${{ inputs.rust && steps.rust-toolchain-cache.outputs.cache-hit != 'true' }}
       with:
         toolchain: ${{ inputs.rust }}

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -112,7 +112,7 @@ runs:
 
     - name: Setup nix
       if: inputs.nix
-      uses: cachix/install-nix-action@754537aaedb35f72ab11a60cc162c49ef3016495 #v31.2.0
+      uses: cachix/install-nix-action@f0fe604f8a612776892427721526b4c7cfb23aba #v31.4.1
       with:
         github_access_token: ${{ inputs.nix-github-token }}
         install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix }}/install

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -112,7 +112,7 @@ runs:
 
     - name: Setup nix
       if: inputs.nix
-      uses: cachix/install-nix-action@f0fe604f8a612776892427721526b4c7cfb23aba #v31.4.1
+      uses: cachix/install-nix-action@f0fe604f8a612776892427721526b4c7cfb23aba # v31.4.1
       with:
         github_access_token: ${{ inputs.nix-github-token }}
         install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix }}/install

--- a/run-pre-commit/action.yml
+++ b/run-pre-commit/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python-version }}
         # It doesn't make a whole lot of sense to use the pre-commit config file

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -17,7 +17,7 @@ runs:
     - name: Retrieve Slack Thread ID
       id: retrieve-slack-thread-id
       continue-on-error: true
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: slack-thread-id-${{ github.run_id }}
 

--- a/shard/action.yml
+++ b/shard/action.yml
@@ -15,7 +15,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
* Bump actions/download-artifact to 4.3.0
* Bump cachix/install-nix-action to 31.4.1
* Bump dtolnay/rust-toolchain to latest commit
* Bump actions/setup-python to 5.6.0
* Bump anchore/sbom-action to 0.20.1
* Bump sigstore/cosign-installer to 3.9.1
* Bump docker/setup-buildx-action to 3.11.1