### PR TITLE
feat: Improve the Slack notification action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+send-slack-notification/templates/* linguist-language=yaml

--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -16,91 +16,90 @@ on:
       - smoke/*
 
 jobs:
-  generate_matrix:
-    name: Generate Version List
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
+  # generate_matrix:
+  #   name: Generate Version List
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         persist-credentials: false
 
-      - id: shard
-        uses: ./shard
-        with:
-          product-name: smoke
-          config-file: smoke/conf.py
-    outputs:
-      versions: ${{ steps.shard.outputs.versions }}
+  #     - id: shard
+  #       uses: ./shard
+  #       with:
+  #         product-name: smoke
+  #         config-file: smoke/conf.py
+  #   outputs:
+  #     versions: ${{ steps.shard.outputs.versions }}
 
-  build:
-    name: Build/Publish Smoke Test (${{ matrix.versions }}-${{ matrix.runner.arch }}) Image
-    needs: [generate_matrix]
-    permissions:
-      id-token: write
-    runs-on: ${{ matrix.runner.name }}
-    strategy:
-      matrix:
-        runner:
-          - {name: "ubuntu-latest", arch: "amd64"}
-          - {name: "ubicloud-standard-8-arm", arch: "arm64"}
-        versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
+  # build:
+  #   name: Build/Publish Smoke Test (${{ matrix.versions }}-${{ matrix.runner.arch }}) Image
+  #   needs: [generate_matrix]
+  #   permissions:
+  #     id-token: write
+  #   runs-on: ${{ matrix.runner.name }}
+  #   strategy:
+  #     matrix:
+  #       runner:
+  #         - {name: "ubuntu-latest", arch: "amd64"}
+  #         - {name: "ubicloud-standard-8-arm", arch: "arm64"}
+  #       versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
+  #   steps:
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         persist-credentials: false
 
-      - name: Free Disk Space
-        uses: ./free-disk-space
+  #     - name: Free Disk Space
+  #       uses: ./free-disk-space
 
-      - name: Build Product Container Image
-        id: build
-        uses: ./build-product-image
-        with:
-          product-name: smoke
-          product-version: ${{ matrix.versions }}
-          bake-config-file: smoke/conf.py
-          extra-tag-data: pr-321
+  #     - name: Build Product Container Image
+  #       id: build
+  #       uses: ./build-product-image
+  #       with:
+  #         product-name: smoke
+  #         product-version: ${{ matrix.versions }}
+  #         bake-config-file: smoke/conf.py
+  #         extra-tag-data: pr-321
 
-      - name: Publish Container Image on oci.stackable.tech
-        uses: ./publish-image
-        with:
-          image-registry-uri: oci.stackable.tech
-          image-registry-username: robot$stackable+github-action-build
-          image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
-          image-repository: stackable/smoke
-          image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}
-          source-image-uri: localhost/smoke:${{ steps.build.outputs.image-manifest-tag }}
+  #     - name: Publish Container Image on oci.stackable.tech
+  #       uses: ./publish-image
+  #       with:
+  #         image-registry-uri: oci.stackable.tech
+  #         image-registry-username: robot$stackable+github-action-build
+  #         image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
+  #         image-repository: stackable/smoke
+  #         image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}
+  #         source-image-uri: localhost/smoke:${{ steps.build.outputs.image-manifest-tag }}
 
-  publish_manifests:
-    name: Build/Publish ${{ matrix.versions }} Index Manifest
-    needs: [generate_matrix, build]
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
+  # publish_manifests:
+  #   name: Build/Publish ${{ matrix.versions }} Index Manifest
+  #   needs: [generate_matrix, build]
+  #   permissions:
+  #     id-token: write
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
+  #   steps:
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #       with:
+  #         persist-credentials: false
 
-      - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: ./publish-index-manifest
-        with:
-          image-registry-uri: oci.stackable.tech
-          image-registry-username: robot$stackable+github-action-build
-          image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
-          image-repository: stackable/smoke
-          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+  #     - name: Publish and Sign Image Index Manifest to oci.stackable.tech
+  #       uses: ./publish-index-manifest
+  #       with:
+  #         image-registry-uri: oci.stackable.tech
+  #         image-registry-username: robot$stackable+github-action-build
+  #         image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
+  #         image-repository: stackable/smoke
+  #         image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
   notify:
     name: Failure Notification
-    needs: [generate_matrix, build, publish_manifests]
     runs-on: ubuntu-latest
-    if: failure() || github.run_attempt > 1
+    # if: failure() || github.run_attempt > 1
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -110,8 +109,8 @@ jobs:
       - name: Send Notification
         uses: ./send-slack-notification
         with:
-          publish-manifests-result: ${{ needs.publish_manifests.result }}
-          build-result: ${{ needs.build.result }}
+          publish-manifests-result: failure
+          build-result: success
           slack-token: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}
           channel-id: C07UG6JH44F # notifications-container-images
           type: container-image-build

--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -114,3 +114,4 @@ jobs:
           build-result: ${{ needs.build.result }}
           slack-token: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}
           channel-id: C07UG6JH44F # notifications-container-images
+          type: container-image-build

--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -102,6 +102,11 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() || github.run_attempt > 1
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - name: Send Notification
         uses: ./send-slack-notification
         with:

--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -16,90 +16,91 @@ on:
       - smoke/*
 
 jobs:
-  # generate_matrix:
-  #   name: Generate Version List
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  #       with:
-  #         persist-credentials: false
+  generate_matrix:
+    name: Generate Version List
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-  #     - id: shard
-  #       uses: ./shard
-  #       with:
-  #         product-name: smoke
-  #         config-file: smoke/conf.py
-  #   outputs:
-  #     versions: ${{ steps.shard.outputs.versions }}
+      - id: shard
+        uses: ./shard
+        with:
+          product-name: smoke
+          config-file: smoke/conf.py
+    outputs:
+      versions: ${{ steps.shard.outputs.versions }}
 
-  # build:
-  #   name: Build/Publish Smoke Test (${{ matrix.versions }}-${{ matrix.runner.arch }}) Image
-  #   needs: [generate_matrix]
-  #   permissions:
-  #     id-token: write
-  #   runs-on: ${{ matrix.runner.name }}
-  #   strategy:
-  #     matrix:
-  #       runner:
-  #         - {name: "ubuntu-latest", arch: "amd64"}
-  #         - {name: "ubicloud-standard-8-arm", arch: "arm64"}
-  #       versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
-  #   steps:
-  #     - name: Checkout Repository
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  #       with:
-  #         persist-credentials: false
+  build:
+    name: Build/Publish Smoke Test (${{ matrix.versions }}-${{ matrix.runner.arch }}) Image
+    needs: [generate_matrix]
+    permissions:
+      id-token: write
+    runs-on: ${{ matrix.runner.name }}
+    strategy:
+      matrix:
+        runner:
+          - {name: "ubuntu-latest", arch: "amd64"}
+          - {name: "ubicloud-standard-8-arm", arch: "arm64"}
+        versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-  #     - name: Free Disk Space
-  #       uses: ./free-disk-space
+      - name: Free Disk Space
+        uses: ./free-disk-space
 
-  #     - name: Build Product Container Image
-  #       id: build
-  #       uses: ./build-product-image
-  #       with:
-  #         product-name: smoke
-  #         product-version: ${{ matrix.versions }}
-  #         bake-config-file: smoke/conf.py
-  #         extra-tag-data: pr-321
+      - name: Build Product Container Image
+        id: build
+        uses: ./build-product-image
+        with:
+          product-name: smoke
+          product-version: ${{ matrix.versions }}
+          bake-config-file: smoke/conf.py
+          extra-tag-data: pr-321
 
-  #     - name: Publish Container Image on oci.stackable.tech
-  #       uses: ./publish-image
-  #       with:
-  #         image-registry-uri: oci.stackable.tech
-  #         image-registry-username: robot$stackable+github-action-build
-  #         image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
-  #         image-repository: stackable/smoke
-  #         image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}
-  #         source-image-uri: localhost/smoke:${{ steps.build.outputs.image-manifest-tag }}
+      - name: Publish Container Image on oci.stackable.tech
+        uses: ./publish-image
+        with:
+          image-registry-uri: oci.stackable.tech
+          image-registry-username: robot$stackable+github-action-build
+          image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
+          image-repository: stackable/smoke
+          image-manifest-tag: ${{ steps.build.outputs.image-manifest-tag }}
+          source-image-uri: localhost/smoke:${{ steps.build.outputs.image-manifest-tag }}
 
-  # publish_manifests:
-  #   name: Build/Publish ${{ matrix.versions }} Index Manifest
-  #   needs: [generate_matrix, build]
-  #   permissions:
-  #     id-token: write
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
-  #   steps:
-  #     - name: Checkout Repository
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  #       with:
-  #         persist-credentials: false
+  publish_manifests:
+    name: Build/Publish ${{ matrix.versions }} Index Manifest
+    needs: [generate_matrix, build]
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        versions: ${{ fromJson(needs.generate_matrix.outputs.versions) }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-  #     - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-  #       uses: ./publish-index-manifest
-  #       with:
-  #         image-registry-uri: oci.stackable.tech
-  #         image-registry-username: robot$stackable+github-action-build
-  #         image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
-  #         image-repository: stackable/smoke
-  #         image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+      - name: Publish and Sign Image Index Manifest to oci.stackable.tech
+        uses: ./publish-index-manifest
+        with:
+          image-registry-uri: oci.stackable.tech
+          image-registry-username: robot$stackable+github-action-build
+          image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
+          image-repository: stackable/smoke
+          image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
 
   notify:
     name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
     runs-on: ubuntu-latest
-    # if: failure() || github.run_attempt > 1
+    if: failure() || github.run_attempt > 1
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -109,8 +110,8 @@ jobs:
       - name: Send Notification
         uses: ./send-slack-notification
         with:
-          publish-manifests-result: failure
-          build-result: success
+          publish-manifests-result: ${{ needs.publish_manifests.result }}
+          build-result: ${{ needs.build.result }}
           slack-token: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}
           channel-id: C07UG6JH44F # notifications-container-images
           type: container-image-build

--- a/.github/workflows/pr_actions-smoke-test.yml
+++ b/.github/workflows/pr_actions-smoke-test.yml
@@ -6,12 +6,13 @@ on:
   pull_request:
     paths:
       - .github/workflows/pr_actions-smoke-test.yml
-      - build-container-image/action.yml
-      - build-product-image/action.yml
-      - free-disk-space/action.yml
-      - publish-image/action.yml
-      - publish-index-manifest/action.yml
-      - shard/action.yml
+      - build-container-image/action.yaml
+      - build-product-image/action.yaml
+      - free-disk-space/action.yaml
+      - publish-image/action.yaml
+      - publish-index-manifest/action.yaml
+      - send-slack-notification/action.yaml
+      - shard/action.yaml
       - smoke/*
 
 jobs:
@@ -94,3 +95,17 @@ jobs:
           image-registry-password: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: stackable/smoke
           image-index-manifest-tag: ${{ matrix.versions }}-stackable0.0.0-dev
+
+  notify:
+    name: Failure Notification
+    needs: [generate_matrix, build, publish_manifests]
+    runs-on: ubuntu-latest
+    if: failure() || github.run_attempt > 1
+    steps:
+      - name: Send Notification
+        uses: ./send-slack-notification
+        with:
+          publish-manifests-result: ${{ needs.publish_manifests.result }}
+          build-result: ${{ needs.build.result }}
+          slack-token: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}
+          channel-id: C07UG6JH44F # notifications-container-images

--- a/run-integration-test/README.md
+++ b/run-integration-test/README.md
@@ -105,8 +105,9 @@ profiles:
 
 - `start-time`
 - `end-time`
-- `health`: The health of the last few runs as a "weather" icon. These icons are geared towards working within Slack messages.
-- `failed-tests`: A (potentially empty) plain text list of failed tests
+- `health`: The health of the integration tests. Contains three comma-separated values: Slack emoji,
+  GitHub emoji, and success rate.
+- `failed-tests`: A (potentially empty) plain text list of failed tests.
 
 [supported-clusters]: https://docs.replicated.com/vendor/testing-supported-clusters
 [run-integration-test]: ./action.yaml

--- a/run-integration-test/README.md
+++ b/run-integration-test/README.md
@@ -105,6 +105,7 @@ profiles:
 
 - `start-time`
 - `end-time`
+- `health`: The health of the last few runs as a "weather" icon. These icons are geared towards working within Slack messages.
 
 [supported-clusters]: https://docs.replicated.com/vendor/testing-supported-clusters
 [run-integration-test]: ./action.yaml

--- a/run-integration-test/README.md
+++ b/run-integration-test/README.md
@@ -106,6 +106,7 @@ profiles:
 - `start-time`
 - `end-time`
 - `health`: The health of the last few runs as a "weather" icon. These icons are geared towards working within Slack messages.
+- `failed-tests`: A (potentially empty) plain text list of failed tests
 
 [supported-clusters]: https://docs.replicated.com/vendor/testing-supported-clusters
 [run-integration-test]: ./action.yaml

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -41,6 +41,9 @@ outputs:
   health:
     description: The health of this integration test over the last few tries.
     value: ${{ steps.health.outputs.HEALTH }}
+  failed-tests:
+    description: The (potentially empty) list of failed tests
+    value: ${{ steps.failed-tests.outputs.FAILED_TESTS }}
 runs:
   using: composite
   steps:
@@ -221,12 +224,12 @@ runs:
         set -euo pipefail
 
         OPERATOR_VERSION=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_operator_version.sh" "$REF_NAME")
-        python ./scripts/run-tests --skip-tests --operator "$OPERATOR_NAME=$OPERATOR_VERSION"
+        python ./scripts/run-tests --skip-tests --operator "$OPERATOR_NAME=$OPERATOR_VERSION" | tee -a test-output.log
 
         [ -n "${BEKU_TEST_SUITE:-}" ] && ARGS+=" --test-suite $BEKU_TEST_SUITE"
         [ -n "${BEKU_TEST:-}" ] && ARGS+=" --test $BEKU_TEST"
 
-        python ./scripts/run-tests --skip-release --log-level debug --parallel "$BEKU_TEST_PARALLELISM" ${ARGS:-}
+        python ./scripts/run-tests --skip-release --log-level debug --parallel "$BEKU_TEST_PARALLELISM" ${ARGS:-} | tee -a test-output.log
 
     - name: Record Test End Time
       id: end-time
@@ -244,6 +247,15 @@ runs:
         # See: https://github.com/replicatedhq/replicated-actions/tree/main/remove-cluster#inputs
         api-token: ${{ inputs.replicated-api-token }}
         cluster-id: ${{ steps.prepare-replicated-cluster.outputs.cluster-id }}
+
+    - name: Extract Failed Tests
+      id: failed-tests
+      if: steps.integration-test.conclusion == "failure"
+      shell: bash
+      run: |
+        # Only look at the last 200 lines of test output which should be more than enough to capture all test results
+        FAILED_TESTS=$(tail --lines 200 test-output.log | grep -E '\s{8}--- FAIL:' | sed -e 's|^.*kuttl/harness/||')
+        echo "FAILED_TESTS=$FAILED_TESTS" | tee -a "$GITHUB_OUTPUT"
 
     - name: Calculate Health
       if: always()

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -264,20 +264,20 @@ runs:
         INTEGRATION_TEST_CONCLUSION: ${{ steps.integration-test.conclusion }}
         WORKFLOW_NAME: "Integration Test"
         GH_TOKEN: ${{ github.token }}
-        LAST_TRIES: "4"
+        LAST_TRIES_LIMIT: "4"
       shell: bash
       run: |
         set -euo pipefail
-
-        export LAST_TRIES="$LAST_TRIES"
 
         # First, we retrieve the number of successes of the last (currently) 4 runs. Afterwards we
         # add 1 to the number of successes if this run succeeded. This ultimately represents the
         # number of successes in the last 5 runs, similar to what Jenkins does. This score is then
         # turned into an appropriate "weather" emoji and provided as an output to follow-up steps.
-        SUCCESSES=$(gh run list --limit "$LAST_TRIES" --workflow "$WORKFLOW_NAME" --json conclusion | jq '[.[] | select(.conclusion == "success")] | length')
-        [ "$CONCLUSION" == "success" ] && SUCCESSES=$(echo "$SUCCESSES+1" | bc)
+        LAST_RUNS=$(gh run list --limit "$LAST_TRIES_LIMIT" --workflow "$WORKFLOW_NAME" --json conclusion)
+        SUCCESSES=$(echo $LAST_RUNS | jq '[.[] | select(.conclusion == "success")] | length')
+        export LAST_TRIES_TOTAL=$(echo $LAST_RUNS | jq 'length')
+
+        [ "$INTEGRATION_TEST_CONCLUSION" == "success" ] && SUCCESSES=$(echo "$SUCCESSES+1" | bc)
         export SUCCESSES="$SUCCESSES"
 
-        # TODO (@Techassi): Emit emojis for both Slack and GitHub
         echo "HEALTH=$(cat "${GITHUB_ACTION_PATH}/health" | envsubst | bc)" | tee -a "$GITHUB_OUTPUT"

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -250,7 +250,7 @@ runs:
 
     - name: Extract Failed Tests
       id: failed-tests
-      if: steps.integration-test.conclusion == "failure"
+      if: steps.integration-test.conclusion == 'failure'
       shell: bash
       run: |
         # Only look at the last 200 lines of test output which should be more than enough to capture all test results

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -68,8 +68,8 @@ runs:
 
         # Run interu to expand parameters into GITHUB_ENV
         if [ "$TEST_MODE" == "profile" ]; then
-          [ -n "${TEST_SUITE:-}" ] && echo ::warning::The test-suite input is ignored, because a profile is selected.
-          [ -n "${TEST:-}" ] && echo ::warning::The test input is ignored, because a profile is selected.
+          [ -n "${TEST_SUITE:-}" ] && echo "::warning::The test-suite input is ignored, because a profile is selected."
+          [ -n "${TEST:-}" ] && echo "::warning::The test input is ignored, because a profile is selected."
 
           interu --instances "$GITHUB_ACTION_PATH/instances.yaml" profile "$TEST_MODE_INPUT" --check-test-definitions --output "$GITHUB_ENV"
         else

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -38,6 +38,9 @@ outputs:
   end-time:
     description: The date and time this integration test finished.
     value: ${{ steps.end-time.outputs.END_TIME }}
+  health:
+    description: The health of this integration test over the last few tries.
+    value: ${{ steps.health.outputs.HEALTH }}
 runs:
   using: composite
   steps:
@@ -209,6 +212,7 @@ runs:
         echo "START_TIME=$(date +'%Y-%m-%dT%H:%M:%S')" | tee -a "$GITHUB_OUTPUT"
 
     - name: Run Integration Test
+      id: integration-test
       env:
         REF_NAME: ${{ github.ref_name }}
         GH_TOKEN: ${{ github.token }}
@@ -240,3 +244,28 @@ runs:
         # See: https://github.com/replicatedhq/replicated-actions/tree/main/remove-cluster#inputs
         api-token: ${{ inputs.replicated-api-token }}
         cluster-id: ${{ steps.prepare-replicated-cluster.outputs.cluster-id }}
+
+    - name: Calculate Health
+      if: always()
+      id: health
+      env:
+        INTEGRATION_TEST_CONCLUSION: ${{ steps.integration-test.conclusion }}
+        WORKFLOW_NAME: "Integration Test"
+        GH_TOKEN: ${{ github.token }}
+        LAST_TRIES: "4"
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        export LAST_TRIES="$LAST_TRIES"
+
+        # First, we retrieve the number of successes of the last (currently) 4 runs. Afterwards we
+        # add 1 to the number of successes if this run succeeded. This ultimately represents the
+        # number of successes in the last 5 runs, similar to what Jenkins does. This score is then
+        # turned into an appropriate "weather" emoji and provided as an output to follow-up steps.
+        SUCCESSES=$(gh run list --limit "$LAST_TRIES" --workflow "$WORKFLOW_NAME" --json conclusion | jq '[.[] | select(.conclusion == "success")] | length')
+        [ "$CONCLUSION" == "success" ] && SUCCESSES=$(echo "$SUCCESSES+1" | bc)
+        export SUCCESSES="$SUCCESSES"
+
+        # TODO (@Techassi): Emit emojis for both Slack and GitHub
+        echo "HEALTH=$(cat "${GITHUB_ACTION_PATH}/health" | envsubst | bc)" | tee -a "$GITHUB_OUTPUT"

--- a/run-integration-test/health
+++ b/run-integration-test/health
@@ -1,26 +1,32 @@
-/* Calculate the percentage of successes of the last few tries (usually 5) */
+/*
+  Calculate the percentage of successes of the last few tries (usually 5) and
+  return emojis suited for Slack and Github and the rate of successes formatted
+  like <successes>/<total_tries>.
+*/
 
 /* Set the scale to 1 to get 1 digit after the decimal point */
 scale = 1
 
 /* Calculate the percentage of successes */
 /* The variables below are replaced by envsubst */
-health = ${SUCCESSES}/(${LAST_TRIES}+1)
+total_tries = ${LAST_TRIES}+1
+successes = ${SUCCESSES}
+health = successes/total_tries
 
-/* Convert the percentage into "weather" icons
+/* Convert the percentage into "weather" icons */
 if (health > 0.8) {
-  print ":sunny:"
+  print ":sunny:,:sunny:,", successes, "/", total_tries
 } else {
   if (health > 0.6) {
-    print ":partly_sunny:"
+    print ":partly_sunny:,:partly_sunny:,", successes, "/", total_tries
   } else {
     if (health > 0.4) {
-      print ":cloud:"
+      print ":cloud:,:cloud:,", successes, "/", total_tries
     } else {
       if (health > 0.2) {
-        print ":rain_cloud:"
+        print ":rain_cloud:,:cloud_with_rain:,", successes, "/", total_tries
       } else {
-        print ":thunder_cloud_and_rain:"
+        print ":thunder_cloud_and_rain:,:cloud_with_lightning_and_rain:,", successes, "/", total_tries
       }
     }
   }

--- a/run-integration-test/health
+++ b/run-integration-test/health
@@ -1,0 +1,29 @@
+/* Calculate the percentage of successes of the last few tries (usually 5) */
+
+/* Set the scale to 1 to get 1 digit after the decimal point */
+scale = 1
+
+/* Calculate the percentage of successes */
+/* The variables below are replaced by envsubst */
+health = ${SUCCESSES}/(${LAST_TRIES}+1)
+
+/* Convert the percentage into "weather" icons
+if (health > 0.8) {
+  print ":sunny:"
+} else {
+  if (health > 0.6) {
+    print ":partly_sunny:"
+  } else {
+    if (health > 0.4) {
+      print ":cloud:"
+    } else {
+      if (health > 0.2) {
+        print ":rain_cloud:"
+      } else {
+        print ":thunder_cloud_and_rain:"
+      }
+    }
+  }
+}
+
+quit

--- a/run-integration-test/health
+++ b/run-integration-test/health
@@ -9,7 +9,7 @@ scale = 1
 
 /* Calculate the percentage of successes */
 /* The variables below are replaced by envsubst */
-total_tries = ${LAST_TRIES}+1
+total_tries = ${LAST_TRIES_TOTAL}+1
 successes = ${SUCCESSES}
 health = successes/total_tries
 

--- a/send-slack-notification/README.md
+++ b/send-slack-notification/README.md
@@ -45,6 +45,7 @@ jobs:
         with:
           type: integration-test
           channel-id: DEADBEEF
+          failed-tests: ${{ needs.job_1.failed-tests }}
           test-result: ${{ needs.job_1.result }}
           test-health: ${{ needs.job_1.health }}
           slack-token: ${{ secrets.MY_SECRET }}

--- a/send-slack-notification/README.md
+++ b/send-slack-notification/README.md
@@ -6,7 +6,11 @@ This action sends a Slack message to notify about container image build failures
 Subsequent attempts of the same workflow run are automatically threaded in Slack.
 The color of the message is automatically selected based on the provided results.
 
-Example usage (workflow):
+## Supported notifications
+
+Currently, two types of notifications are supported.
+
+### Container image builds
 
 ```yaml
 jobs:
@@ -19,8 +23,30 @@ jobs:
       - name: Send Notification
         uses: stackabletech/actions/send-slack-notification
         with:
-          build-result: ${{ needs.job_2.result }}
+          type: container-image-build
+          channel-id: DEADBEEF
+          build-result: ${{ needs.job_1.result }}
           publish-manifests-result: ${{ needs.job_2.result }}
+          slack-token: ${{ secrets.MY_SECRET }}
+```
+
+### Integration tests for operators
+
+```yaml
+jobs:
+  notify:
+    name: Failure Notification
+    needs: [job_1]
+    runs-on: ubuntu-latest
+    if: failure() || github.run_attempt > 1
+    steps:
+      - name: Send Notification
+        uses: stackabletech/actions/send-slack-notification
+        with:
+          type: integration-test
+          channel-id: DEADBEEF
+          test-result: ${{ needs.job_1.result }}
+          test-health: ${{ needs.job_1.health }}
           slack-token: ${{ secrets.MY_SECRET }}
 ```
 
@@ -31,10 +57,11 @@ jobs:
 
 ### Inputs
 
-- `channel-id` (defaults to `C07UG6JH44F`)
-- `build-result` (required, e.g. `success`)
-- `publish-manifests-result` (required, e.g. `failure`)
+- `type` (required, supported values: `container-image-build` and `integration-test`)
+- `channel-id` (required)
 - `slack-token` (required)
+- `build-result` (optional, e.g. `success`)
+- `publish-manifests-result` (optional, e.g. `failure`)
 
 ### Outputs
 

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -76,8 +76,8 @@ runs:
     - name: Format message
       env:
         GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
-        GITHUB_REPOSITORY: ${{ github.repository  }}
-        GITHUB_WORKFLOW: ${{ github.workflow  }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_WORKFLOW: ${{ github.workflow }}
       shell: bash
       run: |
         if [ "$NOTIFICATION_TYPE" == "container-image-build" ]; then

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -111,8 +111,8 @@ runs:
       with:
         method: chat.postMessage
         token: ${{ inputs.slack-token }}
-        payload: |
-          ${{ env.MESSAGE_TEMPLATE }}
+        payload: ${{ env.MESSAGE_TEMPLATE }}
+        payload-templated: true
 
     - name: Save Slack Thread ID to File
       if: steps.retrieve-slack-thread-id.outcome == 'failure'

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -16,6 +16,8 @@ inputs:
     description: The result of an integration test
   test-health:
     description: The health of the past few integration tests
+  failed-tests:
+    description: The list (plain text) of failed tests
   slack-token:
     description: The Slack token
 runs:
@@ -28,6 +30,7 @@ runs:
         PUBLISH_MANIFESTS_RESULT: ${{ inputs.publish-manifests-result }}
         BUILD_RESULT: ${{ inputs.build-result }}
 
+        FAILED_TESTS: ${{ inputs.failed-tests }}
         TEST_RESULT: ${{ inputs.test-result }}
         TEST_HEALTH: ${{ inputs.test-health }}
       shell: bash
@@ -40,13 +43,22 @@ runs:
         if [ "$NOTIFICATION_TYPE" == "container-image-build" ]; then
           [ -n "${PUBLISH_MANIFESTS_RESULT:-}" ] && echo "The publish-manifests-result input must be provided" && exit 1
           [ -n "${BUILD_RESULT:-}" ] && echo "The build-result input must be provided" && exit 1
+
+          echo "PUBLISH_MANIFESTS_RESULT=$PUBLISH_MANIFESTS_RESULT" | tee -a "$GITHUB_ENV"
+          echo "BUILD_RESULT=$BUILD_RESULT" | tee -a "$GITHUB_ENV"
         elif [ "$NOTIFICATION_TYPE" == "integration-test" ]; then
           [ -n "${TEST_RESULT:-}" ] && echo "The test-result input must be provided" && exit 1
           [ -n "${TEST_HEALTH:-}" ] && echo "The test-health input must be provided" && exit 1
+
+          echo "FAILED_TESTS=$FAILED_TESTS" | tee -a "$GITHUB_ENV"
+          echo "TEST_RESULT=$TEST_RESULT" | tee -a "$GITHUB_ENV"
+          echo "TEST_HEALTH=$TEST_HEALTH" | tee -a "$GITHUB_ENV"
         else
           echo "Supported notification types are: 'container-image-build' and 'integration-test'"
           exit 1
         fi
+
+        echo "NOTIFICATION_TYPE=$NOTIFICATION_TYPE" | tee -a "$GITHUB_ENV"
 
     - name: Retrieve Slack Thread ID
       id: retrieve-slack-thread-id
@@ -63,23 +75,35 @@ runs:
 
     - name: Format message
       env:
-        PUBLISH_MANIFESTS_RESULT: ${{ inputs.publish-manifests-result }}
         GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        GITHUB_REPOSITORY: ${{ github.repository  }}
         GITHUB_WORKFLOW: ${{ github.workflow  }}
-        BUILD_RESULT: ${{ inputs.build-result }}
       shell: bash
       run: |
-        if [ "$PUBLISH_MANIFESTS_RESULT" = "failure" ] || [ "$BUILD_RESULT" = "failure" ]; then
-          MESSAGE_VERB=failed
-          MESSAGE_COLOR=aa0000
-        else
-          MESSAGE_VERB=succeeded
-          MESSAGE_COLOR=10c400
-        fi
+        if [ "$NOTIFICATION_TYPE" == "container-image-build" ]; then
+          # TODO (@Techassi): Also add success template
+          if [ "$PUBLISH_MANIFESTS_RESULT" = "failure" ] || [ "$BUILD_RESULT" = "failure" ]; then
+            echo "MESSAGE_VERB=failed" | tee -a "$GITHUB_ENV"
+            echo "MESSAGE_COLOR=aa0000" | tee -a "$GITHUB_ENV"
+          else
+            echo "MESSAGE_VERB=succeeded" | tee -a "$GITHUB_ENV"
+            echo "MESSAGE_COLOR=10c400" | tee -a "$GITHUB_ENV"
+          fi
 
-        echo "MESSAGE_TEXT=*$GITHUB_WORKFLOW* $MESSAGE_VERB (attempt $GITHUB_RUN_ATTEMPT)" | tee -a "$GITHUB_ENV"
-        echo "MESSAGE_COLOR=$MESSAGE_COLOR" | tee -a "$GITHUB_ENV"
-        echo "MESSAGE_VERB=$MESSAGE_VERB" | tee -a "$GITHUB_ENV"
+          echo "MESSAGE_TEXT=*$GITHUB_WORKFLOW* $MESSAGE_VERB (attempt $GITHUB_RUN_ATTEMPT)" | tee -a "$GITHUB_ENV"
+          echo "MESSAGE_TEMPLATE=$(cat ${GITHUB_ACTION_PATH}/templates/container-image-build/failure.tpl)" | tee -a "$GITHUB_ENV"
+        elif [ "$NOTIFICATION_TYPE" == "integration-test" ]; then
+          echo "HEALTH_SLACK_EMOJI=$(cut -d ',' -f 1 $TEST_HEALTH)" | tee -a "$GITHUB_ENV"
+          echo "HEALTH_RATE=$(cut -d ',' -f 3 $TEST_HEALTH)" | tee -a "$GITHUB_ENV"
+
+          if [ "$TEST_RESULT" == "failure" ]; then
+            echo "MESSAGE_TEXT=The integration test for *GITHUB_REPOSITORY* failed" | tee -a "$GITHUB_ENV"
+            echo "MESSAGE_TEMPLATE=$(cat ${GITHUB_ACTION_PATH}/templates/integration-test/failure.tpl)" | tee -a "$GITHUB_ENV"
+          else
+            echo "MESSAGE_TEXT=The integration test for *GITHUB_REPOSITORY* succeeded" | tee -a "$GITHUB_ENV"
+            echo "MESSAGE_TEMPLATE=$(cat ${GITHUB_ACTION_PATH}/templates/integration-test/success.tpl)" | tee -a "$GITHUB_ENV"
+          fi
+        fi
 
     - name: Send Notification
       id: send-notification
@@ -87,24 +111,7 @@ runs:
       with:
         method: chat.postMessage
         token: ${{ inputs.slack-token }}
-        payload: |
-          channel: "${{ inputs.channel-id }}"
-          text: "${{ env.MESSAGE_TEXT }}"
-          ${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
-          attachments:
-            - pretext: "See the details below for a summary of which job(s) ${{ env.MESSAGE_VERB }}."
-              color: "${{ env.MESSAGE_COLOR }}"
-              fields:
-                - title: Build/Publish Image
-                  short: true
-                  value: "${{ inputs.build-result }}"
-                - title: Build/Publish Manifests
-                  short: true
-                  value: "${{ inputs.publish-manifests-result }}"
-              actions:
-                - type: button
-                  text: Go to workflow run
-                  url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+        payload: ${{ env.MESSAGE_TEMPLATE }}
 
     - name: Save Slack Thread ID to File
       if: steps.retrieve-slack-thread-id.outcome == 'failure'

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -83,10 +83,14 @@ runs:
         if [ "$NOTIFICATION_TYPE" == "container-image-build" ]; then
           # TODO (@Techassi): Also add success template
           if [ "$PUBLISH_MANIFESTS_RESULT" = "failure" ] || [ "$BUILD_RESULT" = "failure" ]; then
-            echo "MESSAGE_VERB=failed" | tee -a "$GITHUB_ENV"
+            MESSAGE_VERB=failed
+            echo "MESSAGE_VERB=$MESSAGE_VERB" | tee -a "$GITHUB_ENV"
+
             echo "MESSAGE_COLOR=aa0000" | tee -a "$GITHUB_ENV"
           else
-            echo "MESSAGE_VERB=succeeded" | tee -a "$GITHUB_ENV"
+            MESSAGE_VERB=succeeded
+            echo "MESSAGE_VERB=$MESSAGE_VERB" | tee -a "$GITHUB_ENV"
+
             echo "MESSAGE_COLOR=10c400" | tee -a "$GITHUB_ENV"
           fi
 

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -95,17 +95,17 @@ runs:
           fi
 
           echo "MESSAGE_TEXT=*$GITHUB_WORKFLOW* $MESSAGE_VERB (attempt $GITHUB_RUN_ATTEMPT)" | tee -a "$GITHUB_ENV"
-          echo "MESSAGE_TEMPLATE=$(cat ${GITHUB_ACTION_PATH}/templates/container-image-build/failure.tpl)" | tee -a "$GITHUB_ENV"
+          echo -e "MESSAGE_TEMPLATE<<EOF\n$(cat ${GITHUB_ACTION_PATH}/templates/container-image-build/failure.tpl)\nEOF" | tee -a "$GITHUB_ENV"
         elif [ "$NOTIFICATION_TYPE" == "integration-test" ]; then
           echo "HEALTH_SLACK_EMOJI=$(cut -d ',' -f 1 $TEST_HEALTH)" | tee -a "$GITHUB_ENV"
           echo "HEALTH_RATE=$(cut -d ',' -f 3 $TEST_HEALTH)" | tee -a "$GITHUB_ENV"
 
           if [ "$TEST_RESULT" == "failure" ]; then
             echo "MESSAGE_TEXT=The integration test for *GITHUB_REPOSITORY* failed" | tee -a "$GITHUB_ENV"
-            echo "MESSAGE_TEMPLATE=$(cat ${GITHUB_ACTION_PATH}/templates/integration-test/failure.tpl)" | tee -a "$GITHUB_ENV"
+            echo -e "MESSAGE_TEMPLATE<<EOF\n$(cat ${GITHUB_ACTION_PATH}/templates/integration-test/failure.tpl)\nEOF" | tee -a "$GITHUB_ENV"
           else
             echo "MESSAGE_TEXT=The integration test for *GITHUB_REPOSITORY* succeeded" | tee -a "$GITHUB_ENV"
-            echo "MESSAGE_TEMPLATE=$(cat ${GITHUB_ACTION_PATH}/templates/integration-test/success.tpl)" | tee -a "$GITHUB_ENV"
+            echo -e "MESSAGE_TEMPLATE<<EOF\n$(cat ${GITHUB_ACTION_PATH}/templates/integration-test/success.tpl)\nEOF" | tee -a "$GITHUB_ENV"
           fi
         fi
 

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -111,7 +111,8 @@ runs:
       with:
         method: chat.postMessage
         token: ${{ inputs.slack-token }}
-        payload: ${{ env.MESSAGE_TEMPLATE }}
+        payload: |
+          ${{ env.MESSAGE_TEMPLATE }}
 
     - name: Save Slack Thread ID to File
       if: steps.retrieve-slack-thread-id.outcome == 'failure'

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -1,6 +1,6 @@
 ---
 name: Send Notification via Slack
-description: ""
+description: "This action sends notifications for different types of workflows"
 inputs:
   channel-id:
     description: The channel to sent the message to

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -4,11 +4,18 @@ description: ""
 inputs:
   channel-id:
     description: The channel to sent the message to
-    default: C07UG6JH44F # notifications-container-images
+  type:
+    description: |
+      The type of notification to send. Supported types are `container-image-build`
+      and `integration-test`.
   build-result:
     description: The result of the build job
   publish-manifests-result:
     description: The result of the publish manifests job
+  test-result:
+    description: The result of an integration test
+  test-health:
+    description: The health of the past few integration tests
   slack-token:
     description: The Slack token
 runs:

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -35,20 +35,20 @@ runs:
         TEST_HEALTH: ${{ inputs.test-health }}
       shell: bash
       run: |
-        if [ -n "${NOTIFICATION_TYPE:-}" ]; then
+        if [ -z "${NOTIFICATION_TYPE:-}" ]; then
           echo "The type input must be provided"
           exit 1
         fi
 
         if [ "$NOTIFICATION_TYPE" == "container-image-build" ]; then
-          [ -n "${PUBLISH_MANIFESTS_RESULT:-}" ] && echo "The publish-manifests-result input must be provided" && exit 1
-          [ -n "${BUILD_RESULT:-}" ] && echo "The build-result input must be provided" && exit 1
+          [ -z "${PUBLISH_MANIFESTS_RESULT:-}" ] && echo "The publish-manifests-result input must be provided" && exit 1
+          [ -z "${BUILD_RESULT:-}" ] && echo "The build-result input must be provided" && exit 1
 
           echo "PUBLISH_MANIFESTS_RESULT=$PUBLISH_MANIFESTS_RESULT" | tee -a "$GITHUB_ENV"
           echo "BUILD_RESULT=$BUILD_RESULT" | tee -a "$GITHUB_ENV"
         elif [ "$NOTIFICATION_TYPE" == "integration-test" ]; then
-          [ -n "${TEST_RESULT:-}" ] && echo "The test-result input must be provided" && exit 1
-          [ -n "${TEST_HEALTH:-}" ] && echo "The test-health input must be provided" && exit 1
+          [ -z "${TEST_RESULT:-}" ] && echo "The test-result input must be provided" && exit 1
+          [ -z "${TEST_HEALTH:-}" ] && echo "The test-health input must be provided" && exit 1
 
           echo "FAILED_TESTS=$FAILED_TESTS" | tee -a "$GITHUB_ENV"
           echo "TEST_RESULT=$TEST_RESULT" | tee -a "$GITHUB_ENV"

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -112,6 +112,10 @@ runs:
     - name: Send Notification
       id: send-notification
       uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # 2.1.0
+      env:
+        SLACK_THREAD_YAML: |
+          ${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+        CHANNEL_ID: ${{ inputs.channel-id }}
       with:
         method: chat.postMessage
         token: ${{ inputs.slack-token }}

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -21,6 +21,33 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate Inputs
+      env:
+        NOTIFICATION_TYPE: ${{ inputs.type }}
+
+        PUBLISH_MANIFESTS_RESULT: ${{ inputs.publish-manifests-result }}
+        BUILD_RESULT: ${{ inputs.build-result }}
+
+        TEST_RESULT: ${{ inputs.test-result }}
+        TEST_HEALTH: ${{ inputs.test-health }}
+      shell: bash
+      run: |
+        if [ -n "${NOTIFICATION_TYPE:-}" ]; then
+          echo "The type input must be provided"
+          exit 1
+        fi
+
+        if [ "$NOTIFICATION_TYPE" == "container-image-build" ]; then
+          [ -n "${PUBLISH_MANIFESTS_RESULT:-}" ] && echo "The publish-manifests-result input must be provided" && exit 1
+          [ -n "${BUILD_RESULT:-}" ] && echo "The build-result input must be provided" && exit 1
+        elif [ "$NOTIFICATION_TYPE" == "integration-test" ]; then
+          [ -n "${TEST_RESULT:-}" ] && echo "The test-result input must be provided" && exit 1
+          [ -n "${TEST_HEALTH:-}" ] && echo "The test-health input must be provided" && exit 1
+        else
+          echo "Supported notification types are: 'container-image-build' and 'integration-test'"
+          exit 1
+        fi
+
     - name: Retrieve Slack Thread ID
       id: retrieve-slack-thread-id
       continue-on-error: true

--- a/send-slack-notification/templates/container-image-build/failure.tpl
+++ b/send-slack-notification/templates/container-image-build/failure.tpl
@@ -1,0 +1,17 @@
+channel: "${{ inputs.channel-id }}"
+text: "${{ env.MESSAGE_TEXT }}"
+${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+attachments:
+  - pretext: "See the details below for a summary of which job(s) ${{ env.MESSAGE_VERB }}."
+    color: "${{ env.MESSAGE_COLOR }}"
+    fields:
+      - title: Build/Publish Image
+        short: true
+        value: "${{ inputs.build-result }}"
+      - title: Build/Publish Manifests
+        short: true
+        value: "${{ inputs.publish-manifests-result }}"
+    actions:
+      - type: button
+        text: Go to workflow run
+        url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/send-slack-notification/templates/container-image-build/failure.tpl
+++ b/send-slack-notification/templates/container-image-build/failure.tpl
@@ -1,16 +1,16 @@
-channel: "${{ inputs.channel-id }}"
+channel: "${{ env.CHANNEL_ID }}"
 text: "${{ env.MESSAGE_TEXT }}"
-${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+${{ env.SLACK_THREAD_YAML }}
 attachments:
   - pretext: "See the details below for a summary of which job(s) ${{ env.MESSAGE_VERB }}."
     color: "${{ env.MESSAGE_COLOR }}"
     fields:
       - title: Build/Publish Image
         short: true
-        value: "${{ inputs.build-result }}"
+        value: "${{ env.BUILD_RESULT }}"
       - title: Build/Publish Manifests
         short: true
-        value: "${{ inputs.publish-manifests-result }}"
+        value: "${{ env.PUBLISH_MANIFESTS_RESULT }}"
     actions:
       - type: button
         text: Go to workflow run

--- a/send-slack-notification/templates/integration-test/failure.tpl
+++ b/send-slack-notification/templates/integration-test/failure.tpl
@@ -1,6 +1,6 @@
-channel: "${{ inputs.channel-id }}"
+channel: "${{ env.CHANNEL_ID }}"
 text: "${{ env.MESSAGE_TEXT }}"
-${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+${{ env.SLACK_THREAD_YAML }}
 blocks:
   - type: "section"
     text:

--- a/send-slack-notification/templates/integration-test/failure.tpl
+++ b/send-slack-notification/templates/integration-test/failure.tpl
@@ -1,0 +1,29 @@
+channel: "${{ inputs.channel-id }}"
+text: "${{ env.MESSAGE_TEXT }}"
+${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+blocks:
+  - type: "section"
+    text:
+      type: "mrkdwn"
+      text: "${{ env.HEALTH_SLACK_EMOJI }} (${{ env.HEALTH_RATE }})" The integration test failed because of the following individual tests:"
+  - type: "rich_text"
+    border: 0
+    elements:
+      - type: "rich_text_preformatted"
+        elements:
+          - type: "text"
+            text: "${{ env.FAILED_TESTS }}"
+  - type: "actions"
+    elements:
+      - type: button
+        text:
+          type: "plain_text"
+          text: "View Workflow Run"
+          emoji: false
+        url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+      - type: button
+        text:
+          type: "plain_text"
+          text: "View Dashboard"
+          emoji: false
+        url: "https://example.org"

--- a/send-slack-notification/templates/integration-test/success.tpl
+++ b/send-slack-notification/templates/integration-test/success.tpl
@@ -1,6 +1,6 @@
-channel: "${{ inputs.channel-id }}"
+channel: "${{ env.CHANNEL_ID }}"
 text: "${{ env.MESSAGE_TEXT }}"
-${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+${{ env.SLACK_THREAD_YAML }}
 blocks:
   - type: "section"
     text:

--- a/send-slack-notification/templates/integration-test/success.tpl
+++ b/send-slack-notification/templates/integration-test/success.tpl
@@ -1,0 +1,22 @@
+channel: "${{ inputs.channel-id }}"
+text: "${{ env.MESSAGE_TEXT }}"
+${{ steps.retrieve-slack-thread-id.outcome == 'success' && format('thread_ts: "{0}"', env.SLACK_THREAD_ID) || '' }}
+blocks:
+  - type: "section"
+    text:
+      type: "mrkdwn"
+      text: "${{ env.HEALTH_SLACK_EMOJI }} (${{ env.HEALTH_RATE }})" The integration test for *${{ github.repository }}* succeeded."
+  - type: "actions"
+    elements:
+      - type: button
+        text:
+          type: "plain_text"
+          text: "View Workflow Run"
+          emoji: false
+        url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+      - type: button
+        text:
+          type: "plain_text"
+          text: "View Dashboard"
+          emoji: false
+        url: "https://example.org"


### PR DESCRIPTION
This PR adds the following changes:

- The `health` output of the `run-integration-test` action returns a "weather" icon representing the success rate of the last few test runs similar to how Jenkins does it.
- The `send-slack-notification` action now supports two types of notifications: `container-image-build` and `integration-test`. They both expect different inputs and will send different Slack messages.