### PR TITLE
fix: Remove superfluous double quote from templates

### DIFF
--- a/send-slack-notification/templates/integration-test/failure.tpl
+++ b/send-slack-notification/templates/integration-test/failure.tpl
@@ -5,7 +5,7 @@ blocks:
   - type: "section"
     text:
       type: "mrkdwn"
-      text: "${{ env.HEALTH_SLACK_EMOJI }} (${{ env.HEALTH_RATE }})" The integration test failed because of the following individual tests:"
+      text: "${{ env.HEALTH_SLACK_EMOJI }} (${{ env.HEALTH_RATE }}) The integration test failed because of the following individual tests:"
   - type: "rich_text"
     border: 0
     elements:

--- a/send-slack-notification/templates/integration-test/success.tpl
+++ b/send-slack-notification/templates/integration-test/success.tpl
@@ -5,7 +5,7 @@ blocks:
   - type: "section"
     text:
       type: "mrkdwn"
-      text: "${{ env.HEALTH_SLACK_EMOJI }} (${{ env.HEALTH_RATE }})" The integration test for *${{ github.repository }}* succeeded."
+      text: "${{ env.HEALTH_SLACK_EMOJI }} (${{ env.HEALTH_RATE }}) The integration test for *${{ github.repository }}* succeeded."
   - type: "actions"
     elements:
       - type: button


### PR DESCRIPTION
This somehow slipped through.