### PR TITLE
fix(send-slack-notification): Provide failed-tests default value

### DIFF
--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -73,13 +73,18 @@ runs:
       run: |
         echo "SLACK_THREAD_ID=$(cat slack-thread-id)" | tee -a "$GITHUB_ENV"
 
-    - name: Format message
+    - name: Provide message template variables
       env:
         GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+        GITHUB_SERVER_URL: ${{ github.server_url }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_WORKFLOW: ${{ github.workflow }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
       shell: bash
       run: |
+        WORKFLOW_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}"
+        echo "WORKFLOW_RUN_URL=$WORKFLOW_RUN_URL" | tee -a "$GITHUB_ENV"
+
         if [ "$NOTIFICATION_TYPE" == "container-image-build" ]; then
           # TODO (@Techassi): Also add success template
           if [ "$PUBLISH_MANIFESTS_RESULT" = "failure" ] || [ "$BUILD_RESULT" = "failure" ]; then

--- a/send-slack-notification/templates/container-image-build/failure.tpl
+++ b/send-slack-notification/templates/container-image-build/failure.tpl
@@ -14,4 +14,4 @@ attachments:
     actions:
       - type: button
         text: Go to workflow run
-        url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+        url: "${{ env.WORKFLOW_RUN_URL }}"

--- a/send-slack-notification/templates/integration-test/failure.tpl
+++ b/send-slack-notification/templates/integration-test/failure.tpl
@@ -19,7 +19,7 @@ blocks:
           type: "plain_text"
           text: "View Workflow Run"
           emoji: false
-        url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+        url: "${{ env.WORKFLOW_RUN_URL }}"
       - type: button
         text:
           type: "plain_text"

--- a/send-slack-notification/templates/integration-test/success.tpl
+++ b/send-slack-notification/templates/integration-test/success.tpl
@@ -13,7 +13,7 @@ blocks:
           type: "plain_text"
           text: "View Workflow Run"
           emoji: false
-        url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
+        url: "${{ env.WORKFLOW_RUN_URL }}"
       - type: button
         text:
           type: "plain_text"


### PR DESCRIPTION
This condition is encountered if no integration test ran, but the step still failed. This can be the case if other steps failed, like creating the cluster, applying other resources to said cluster, etc. The field in the Slack message needs to be non-empty. As such, we now provide a default value.