### PR TITLE
chore: Release interu 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "interu"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "rand",

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -21,7 +21,7 @@ inputs:
   # Tool versions
   interu-version:
     description: Version of interu
-    default: 0.2.0-rc.1
+    default: 0.2.0
   beku-version:
     description: Version of beku
     default: 0.0.10

--- a/tools/interu/Cargo.toml
+++ b/tools/interu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interu"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
The 0.2.0-rc.1 version worked without any further issues. As such, we can now release the 0.2.0 version of interu.