### PR TITLE
fix(run-integration-test/telemetry): Bump otel-operator to 0.93.0

### DIFF
--- a/run-integration-test/kustomize/bases/opentelemetry-operator/kustomization.yml
+++ b/run-integration-test/kustomize/bases/opentelemetry-operator/kustomization.yml
@@ -9,7 +9,7 @@ helmCharts:
 - name: opentelemetry-operator
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
   # Find the latest release here: https://github.com/open-telemetry/opentelemetry-helm-charts/releases
-  version: 0.92.2
+  version: 0.93.0
   releaseName: opentelemetry-operator
   includeCRDs: true
   skipTests: true
@@ -22,7 +22,7 @@ helmCharts:
         # See which plugins the opentelemetry-collector-k8s image contains here:
         # https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-k8s/manifest.yaml
         repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
-        tag: 0.131.1 # Often the chart has old values for the collector image
+        tag: 0.132.4 # Often the chart has old values for the collector image
     admissionWebhooks:
       certManager:
         enabled: false


### PR DESCRIPTION
This gets past the [invalid values JSON](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1805) schema [now enforced by Helm](https://github.com/helm/helm/releases/tag/v3.18.5).