### PR TITLE
feat(run-integration-test): Support pinned kubectl and helm versions

### DIFF
--- a/.scripts/actions/get_platform.sh
+++ b/.scripts/actions/get_platform.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Get the platform/system as a lowercase string
+uname -s | tr '[:upper:]' '[:lower:]'

--- a/run-integration-test/README.md
+++ b/run-integration-test/README.md
@@ -100,7 +100,9 @@ profiles:
 | `test`                 | No       | The name of the BeKu test (only used if running a `custom` test)       |
 | `interu-version`       | No       | The interu version used by the action                                  |
 | `beku-version`         | No       | The beku version used by the action                                    |
+| `kubectl-version`      | No       | The kubectl version used by the action                                 |
 | `kuttl-version`        | No       | The kubectl-kuttl version used by the action                           |
+| `helm-version`         | No       | The helm version used by the action                                    |
 | `stackablectl-version` | No       | The stackablectl version used by the action                            |
 
 ### Outputs

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -112,8 +112,12 @@ runs:
 
         ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
 
+        echo "::group::Install kubectl"
         curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
         sudo install -m 755 -t /usr/local/bin /tmp/kubectl
+
+        kubectl version
+        echo "::endgroup::"
 
     - name: Install Helm
       env:
@@ -129,6 +133,7 @@ runs:
 
         FILENAME="helm-${HELM_VERSION}-${PLATFORM}-${ARCH}.tar.gz"
 
+        echo "::group::Install helm"
         mkdir /tmp/helm
         curl -fsSL -o /tmp/helm/helm.tar.gz "https://get.helm.sh/${FILENAME}"
         curl -fsSL -o /tmp/helm/helm.tar.gz.asc "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${FILENAME}.asc"
@@ -138,6 +143,9 @@ runs:
 
         tar --directory="/tmp/helm" --strip-components=1 -zxvf /tmp/helm/helm.tar.gz "${PLATFORM}-${ARCH}"
         sudo install -m 755 -t /usr/local/bin /tmp/helm/helm
+
+        helm version
+        echo "::endgroup::"
 
     - name: Install kubectl-kuttl
       env:

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -114,6 +114,7 @@ runs:
 
         echo "::group::Install kubectl"
         curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+        # Overwrite the existing binary
         sudo install -m 755 -t /usr/local/bin /tmp/kubectl
 
         kubectl version
@@ -142,6 +143,7 @@ runs:
         gpg --verify /tmp/helm/helm.tar.gz.asc /tmp/helm/helm.tar.gz
 
         tar --directory="/tmp/helm" --strip-components=1 -zxvf /tmp/helm/helm.tar.gz "${PLATFORM}-${ARCH}"
+        # Overwrite the existing binary
         sudo install -m 755 -t /usr/local/bin /tmp/helm/helm
 
         helm version

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -21,15 +21,27 @@ inputs:
   # Tool versions
   interu-version:
     description: Version of interu
+    # See https://github.com/stackabletech/actions/releases for latest version
     default: 0.2.0
   beku-version:
     description: Version of beku
+    # See https://github.com/stackabletech/beku.py/releases for latest version
     default: 0.0.10
+  kubectl-version:
+    description: Version of kubectl
+    # See https://dl.k8s.io/release/stable.txt for latest version
+    default: v1.33.4
   kuttl-version:
     description: Version of kubectl-kuttl
+    # See https://github.com/kudobuilder/kuttl/releases for latest version
     default: 0.22.0
+  helm-version:
+    description: Version of helm
+    # See https://github.com/helm/helm/releases for latest version
+    default: v3.18.6
   stackablectl-version:
     description: Version of stackablectl
+    # See https://github.com/stackabletech/stackable-cockpit/releases for latest version
     default: 1.1.0
 outputs:
   start-time:
@@ -86,15 +98,55 @@ runs:
     # and are therefore not available, there is no need to create the cluster or run the tests,
     # because the tests can never run in the first place.
 
-    # We don't need to install kubectl, kind or helm because it is already part of the installed
-    # tools of the runner image.
+    # We technically don't need to install kubectl, kind or helm because it is already part of the installed
+    # tools of the runner image, but we at least install kubectl and helm explicitly, to be able to pin the versions.
     # See https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-kubernetes-tools.sh
-    - name: Install kubectl-kuttl
+    - name: Install kubectl
       env:
-        KUTTL_VERSION: ${{ inputs.kuttl-version }}
+        KUBECTL_VERSION: ${{ inputs.kubectl-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
+
+        curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+        sudo install -m 755 -t /usr/local/bin /tmp/kubectl
+
+    - name: Install Helm
+      env:
+        HELM_VERSION: ${{ inputs.helm-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        PLATFORM=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_platform.sh")
+        ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
+
+        FILENAME="helm-${HELM_VERSION}-${PLATFORM}-${ARCH}.tar.gz"
+
+        mkdir /tmp/helm
+        curl -fsSL -o /tmp/helm/helm.tar.gz "https://get.helm.sh/${FILENAME}"
+        curl -fsSL -o /tmp/helm/helm.tar.gz.asc "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${FILENAME}.asc"
+
+        curl https://keybase.io/mattfarina/pgp_keys.asc | gpg --import
+        gpg --verify /tmp/helm/helm.tar.gz.asc /tmp/helm/helm.tar.gz
+
+        tar --directory="/tmp/helm" --strip-components=1 -zxvf /tmp/helm/helm.tar.gz "${PLATFORM}-${ARCH}"
+        sudo install -m 755 -t /usr/local/bin /tmp/helm/helm
+
+    - name: Install kubectl-kuttl
+      env:
+        KUTTL_VERSION: ${{ inputs.kuttl-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
 
         curl -fsSL -o /tmp/kubectl-kuttl "https://github.com/kudobuilder/kuttl/releases/download/v$KUTTL_VERSION/kubectl-kuttl_${KUTTL_VERSION}_linux_x86_64"
         sudo install -m 755 -t /usr/local/bin /tmp/kubectl-kuttl


### PR DESCRIPTION
Add support to pin `kubectl` and `helm` versions to avoid breakages like https://github.com/stackabletech/zookeeper-operator/actions/runs/17124645488 which was fixed in #64.