### PR TITLE
fix(run-integration-test): Only print kubectl's client version

### DIFF
--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -117,7 +117,7 @@ runs:
         # Overwrite the existing binary
         sudo install -m 755 -t /usr/local/bin /tmp/kubectl
 
-        kubectl version
+        kubectl version --client
         echo "::endgroup::"
 
     - name: Install Helm
@@ -146,7 +146,7 @@ runs:
         # Overwrite the existing binary
         sudo install -m 755 -t /usr/local/bin /tmp/helm/helm
 
-        helm version
+        helm version --short
         echo "::endgroup::"
 
     - name: Install kubectl-kuttl


### PR DESCRIPTION
Fixes error encountered in https://github.com/stackabletech/airflow-operator/actions/runs/17153631486/job/48665331292.