### PR TITLE
fix(send-slack-notification): Include operator name in message

### DIFF
--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -106,10 +106,10 @@ runs:
           echo "HEALTH_RATE=$(echo "$TEST_HEALTH" | cut -d ',' -f 3)" | tee -a "$GITHUB_ENV"
 
           if [ "$TEST_RESULT" == "failure" ]; then
-            echo "MESSAGE_TEXT=The integration test for *$GITHUB_REPOSITORY* failed" | tee -a "$GITHUB_ENV"
+            echo "MESSAGE_TEXT=The integration test for *`$GITHUB_REPOSITORY`* failed." | tee -a "$GITHUB_ENV"
             echo -e "MESSAGE_TEMPLATE<<EOF\n$(cat ${GITHUB_ACTION_PATH}/templates/integration-test/failure.tpl)\nEOF" | tee -a "$GITHUB_ENV"
           else
-            echo "MESSAGE_TEXT=The integration test for *$GITHUB_REPOSITORY* succeeded" | tee -a "$GITHUB_ENV"
+            echo "MESSAGE_TEXT=The integration test for *`$GITHUB_REPOSITORY`* succeeded." | tee -a "$GITHUB_ENV"
             echo -e "MESSAGE_TEMPLATE<<EOF\n$(cat ${GITHUB_ACTION_PATH}/templates/integration-test/success.tpl)\nEOF" | tee -a "$GITHUB_ENV"
           fi
         fi

--- a/send-slack-notification/templates/integration-test/failure.tpl
+++ b/send-slack-notification/templates/integration-test/failure.tpl
@@ -1,7 +1,10 @@
 channel: "${{ env.CHANNEL_ID }}"
-text: "${{ env.MESSAGE_TEXT }}"
 ${{ env.SLACK_THREAD_YAML }}
 blocks:
+  - type: "section"
+    text:
+      type: "mrkdwn"
+      text: "${{ env.MESSAGE_TEXT }}"
   - type: "section"
     text:
       type: "mrkdwn"

--- a/send-slack-notification/templates/integration-test/success.tpl
+++ b/send-slack-notification/templates/integration-test/success.tpl
@@ -1,7 +1,10 @@
 channel: "${{ env.CHANNEL_ID }}"
-text: "${{ env.MESSAGE_TEXT }}"
 ${{ env.SLACK_THREAD_YAML }}
 blocks:
+  - type: "section"
+    text:
+      type: "mrkdwn"
+      text: "${{ env.MESSAGE_TEXT }}"
   - type: "section"
     text:
       type: "mrkdwn"


### PR DESCRIPTION
This includes the operator name in the integration test notification message, as the `text` field seems to do nothing (?).