### PR TITLE
feat: Add setup-tools and setup-k8s-tools actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,7 @@ particular step in a workflow.
 - [run-integration-test](./run-integration-test/README.md)
 - [run-pre-commit](./run-pre-commit/README.md)
 - [send-slack-notification](./send-slack-notification/README.md)
+- [setup-k8s-tools](./setup-k8s-tools/README.md)
+- [setup-tools](./setup-tools/README.md)
 - [shard](./shard/README.md)
 <!-- end:links -->

--- a/setup-k8s-tools/README.md
+++ b/setup-k8s-tools/README.md
@@ -1,0 +1,26 @@
+# `setup-k8s-tools`
+
+> Manifest: [setup-k8s-tools/action.yml][setup-k8s-tools]
+
+This action downloads and installs Kubernetes tools.
+
+## Inputs and Outputs
+
+> [!TIP]
+> For descriptions of the inputs and outputs, see the complete [setup-k8s-tools] action.
+
+### Inputs
+
+| Input             | Required | Description                   |
+| ----------------- | -------- | ----------------------------- |
+| `kubectl-version` | No       | The version of kubectl*       |
+| `kuttl-version`   | No       | The version of kubectl-kuttl* |
+| `helm-version`    | No       | The version of helm*          |
+
+\* If no input is set, the tool won't be installed.
+
+### Outputs
+
+None.
+
+[setup-k8s-tools]: ./action.yaml

--- a/setup-k8s-tools/action.yaml
+++ b/setup-k8s-tools/action.yaml
@@ -1,0 +1,80 @@
+---
+name: Setup Kubernetes Tools
+description: This action sets up Kubernetes tools
+inputs:
+  kubectl-version:
+    description: The version of kubectl
+  kuttl-version:
+    description: The version of kubectl-kuttl
+  helm-version:
+    description: The version of helm
+runs:
+  using: composite
+  steps:
+    # We technically don't need to install kubectl, kind or helm because it is already part of the installed
+    # tools of the runner image, but we at least install kubectl and helm explicitly, to be able to pin the versions.
+    # See https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+    - name: Install kubectl
+      if: inputs.kubectl-version
+      env:
+        KUBECTL_VERSION: ${{ inputs.kubectl-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
+
+        echo "::group::Install kubectl"
+        curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+        # Overwrite the existing binary
+        sudo install -m 755 -t /usr/local/bin /tmp/kubectl
+
+        kubectl version --client
+        echo "::endgroup::"
+
+    - name: Install kubectl-kuttl
+      if: inputs.kuttl-version
+      env:
+        KUTTL_VERSION: ${{ inputs.kuttl-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        echo "::group::Install kubectl-kuttl"
+        curl -fsSL -o /tmp/kubectl-kuttl "https://github.com/kudobuilder/kuttl/releases/download/v$KUTTL_VERSION/kubectl-kuttl_${KUTTL_VERSION}_linux_x86_64"
+        sudo install -m 755 -t /usr/local/bin /tmp/kubectl-kuttl
+        echo "::endgroup::"
+
+    - name: Install Helm
+      if: inputs.helm-version
+      env:
+        HELM_VERSION: ${{ inputs.helm-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        PLATFORM=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_platform.sh")
+        ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
+
+        FILENAME="helm-${HELM_VERSION}-${PLATFORM}-${ARCH}.tar.gz"
+
+        echo "::group::Install helm"
+        mkdir /tmp/helm
+        curl -fsSL -o /tmp/helm/helm.tar.gz "https://get.helm.sh/${FILENAME}"
+        curl -fsSL -o /tmp/helm/helm.tar.gz.asc "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${FILENAME}.asc"
+
+        curl https://keybase.io/mattfarina/pgp_keys.asc | gpg --import
+        gpg --verify /tmp/helm/helm.tar.gz.asc /tmp/helm/helm.tar.gz
+
+        tar --directory="/tmp/helm" --strip-components=1 -zxvf /tmp/helm/helm.tar.gz "${PLATFORM}-${ARCH}"
+        # Overwrite the existing binary
+        sudo install -m 755 -t /usr/local/bin /tmp/helm/helm
+
+        helm version --short
+        echo "::endgroup::"

--- a/setup-tools/README.md
+++ b/setup-tools/README.md
@@ -1,0 +1,27 @@
+# `setup-tools`
+
+> Manifest: [setup-tools/action.yml][setup-tools]
+
+This action downloads and installs Stackable tools.
+
+## Inputs and Outputs
+
+> [!TIP]
+> For descriptions of the inputs and outputs, see the complete [setup-tools] action.
+
+### Inputs
+
+| Input                  | Required | Description                  |
+| ---------------------- | -------- | ---------------------------- |
+| `boil-version`         | No       | The version of boil*         |
+| `stackablectl-version` | No       | The version of stackablectl* |
+| `interu-version`       | No       | The version of interu*       |
+| `beku-version`         | No       | The version of beku*         |
+
+\* If no input is set, the tool won't be installed.
+
+### Outputs
+
+None.
+
+[setup-tools]: ./action.yaml

--- a/setup-tools/action.yaml
+++ b/setup-tools/action.yaml
@@ -1,0 +1,71 @@
+---
+name: Setup Stackable Tools
+description: This action sets up Stackable tools
+inputs:
+  boil-version:
+    description: The version of boil
+  stackablectl-version:
+    description: The version of stackablectl
+  interu-version:
+    description: The version of interu
+  beku-version:
+    description: The version of beku
+runs:
+  using: composite
+  steps:
+    - name: Install boil
+      if: inputs.boil-version
+      env:
+        BOIL_VERSION: ${{ inputs.boil-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        ARCH=$(uname -m)
+
+        curl -fsSL -o /tmp/boil "https://github.com/stackabletech/docker-images/releases/download/boil-${BOIL_VERSION}/boil-${ARCH}-unknown-linux-gnu"
+        sudo install -m 755 -t /usr/local/bin /tmp/boil
+
+    - name: Install stackablectl
+      if: inputs.stackablectl-version
+      env:
+        STACKABLECTL_VERSION: ${{ inputs.stackablectl-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        ARCH=$(uname -m)
+
+        curl -fsSL -o /tmp/stackablectl "https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-${STACKABLECTL_VERSION}/stackablectl-${ARCH}-unknown-linux-gnu"
+        sudo install -m 755 -t /usr/local/bin /tmp/stackablectl
+
+    - name: Install interu
+      if: inputs.interu-version
+      env:
+        INTERU_VERSION: ${{ inputs.interu-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        ARCH=$(uname -m)
+
+        curl -fsSL -o /tmp/interu "https://github.com/stackabletech/actions/releases/download/interu-${INTERU_VERSION}/interu-${ARCH}-unknown-linux-gnu"
+        sudo install -m 755 -t /usr/local/bin /tmp/interu
+
+    - name: Install beku
+      if: inputs.beku-version
+      env:
+        BEKU_VERSION: ${{ inputs.beku-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        pip install "beku-stackabletech==$BEKU_VERSION"


### PR DESCRIPTION
This PR adds two new actions:

- `setup-tools`: Installs selected Stackable tools, like beku, boil, etc.
- `setup-k8s-tools`: Installs selected Kubernetes tools, like kubectl, helm, etc.