### PR TITLE
fix(run-preflight-check): Don't prefix platform with 'linux/'

### DIFF
--- a/run-openshift-preflight/action.yaml
+++ b/run-openshift-preflight/action.yaml
@@ -46,7 +46,7 @@ runs:
         set -euo pipefail
         [ -n "$GITHUB_DEBUG" ] && set -x
 
-        openshift-preflight check container "$IMAGE_INDEX_URI" --platform "linux/$IMAGE_ARCHITECTURE" > preflight.out
+        openshift-preflight check container "$IMAGE_INDEX_URI" --platform "$IMAGE_ARCHITECTURE" > preflight.out
 
     - name: Report Result
       env:


### PR DESCRIPTION
More weird decisions from RedHat.

- Docker and other tools expect the full platform, like `linux/amd64`.
- The preflight check tool only expects `amd64`, so the architecture, but the argument is still called `--platform`.