### PR TITLE
fix(run-integration-test): Pin setup-tools action

### DIFF
--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -60,7 +60,7 @@ runs:
   using: composite
   steps:
     - name: Install interu
-      uses: stackabletech/actions/setup-tools
+      uses: stackabletech/actions/setup-tools@7279ffd852a8013df52028de0d99eef68700f803 # TODO: Pin this to the latest tag
       with:
         interu-version: ${{ inputs.interu-version }}
     - name: Extract Test and Instance Configuration
@@ -97,7 +97,7 @@ runs:
     # and are therefore not available, there is no need to create the cluster or run the tests,
     # because the tests can never run in the first place.
     - name: Install kubectl, kubectl-kuttl, and helm
-      uses: stackablectl/actions/setup-k8s-tools
+      uses: stackablectl/actions/setup-k8s-tools@7279ffd852a8013df52028de0d99eef68700f803 # TODO: Pin this to the latest tag
       with:
         kubectl-version: ${{ inputs.kubectl-version }}
         kuttl-version: ${{ inputs.kuttl-version }}
@@ -110,7 +110,7 @@ runs:
     # mikefarah/yq is already installed on the runner
     # See https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-yq.sh
     - name: Install stackablectl and beku
-      uses: stackabletech/actions/setup-tools
+      uses: stackabletech/actions/setup-tools@7279ffd852a8013df52028de0d99eef68700f803 # TODO: Pin this to the latest tag
       with:
         stackablectl-version: ${{ inputs.stackablectl-version }}
         beku-version: ${{ inputs.beku-version }}


### PR DESCRIPTION
All actions must use a rev. They are not able to run otherwise.