### PR TITLE
feat(run-openshift-preflight): Print preflight log

### DIFF
--- a/run-openshift-preflight/action.yaml
+++ b/run-openshift-preflight/action.yaml
@@ -62,5 +62,6 @@ runs:
         else
           echo "Checks failed"
           cat preflight.out
+          cat preflight.log
           exit 1
         fi


### PR DESCRIPTION
Print the `preflight.log` if the check failed. This should provide more details on _why_ the check(s) failed.