### PR TITLE
refactor: Use install scripts

### DIFF
--- a/.scripts/actions/install_boil.sh
+++ b/.scripts/actions/install_boil.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "$GITHUB_DEBUG" ] && set -x
+
+ARCH=$(uname -m)
+
+if [ "$BOIL_VERSION" == "latest" ]; then
+  curl -fsSL -o /tmp/boil "https://github.com/stackabletech/docker-images/releases/latest/download/boil-${ARCH}-unknown-linux-gnu"
+else
+  curl -fsSL -o /tmp/boil "https://github.com/stackabletech/docker-images/releases/download/boil-${BOIL_VERSION}/boil-${ARCH}-unknown-linux-gnu"
+fi
+
+sudo install -m 755 -t /usr/local/bin /tmp/boil

--- a/.scripts/actions/install_helm.sh
+++ b/.scripts/actions/install_helm.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "$GITHUB_DEBUG" ] && set -x
+
+PLATFORM=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_platform.sh")
+ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
+
+FILENAME="helm-${HELM_VERSION}-${PLATFORM}-${ARCH}.tar.gz"
+
+echo "::group::Install helm"
+mkdir /tmp/helm
+curl -fsSL -o /tmp/helm/helm.tar.gz "https://get.helm.sh/${FILENAME}"
+curl -fsSL -o /tmp/helm/helm.tar.gz.asc "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${FILENAME}.asc"
+
+curl https://keybase.io/mattfarina/pgp_keys.asc | gpg --import
+gpg --verify /tmp/helm/helm.tar.gz.asc /tmp/helm/helm.tar.gz
+
+tar --directory="/tmp/helm" --strip-components=1 -zxvf /tmp/helm/helm.tar.gz "${PLATFORM}-${ARCH}"
+# Overwrite the existing binary
+sudo install -m 755 -t /usr/local/bin /tmp/helm/helm
+
+helm version --short
+echo "::endgroup::"

--- a/.scripts/actions/install_interu.sh
+++ b/.scripts/actions/install_interu.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "$GITHUB_DEBUG" ] && set -x
+
+ARCH=$(uname -m)
+
+if [ "$INTERU_VERSION" == "latest" ]; then
+  curl -fsSL -o /tmp/interu "https://github.com/stackabletech/actions/releases/latest/download/interu-${ARCH}-unknown-linux-gnu"
+else
+  curl -fsSL -o /tmp/interu "https://github.com/stackabletech/actions/releases/download/interu-${INTERU_VERSION}/interu-${ARCH}-unknown-linux-gnu"
+fi
+
+sudo install -m 755 -t /usr/local/bin /tmp/interu

--- a/.scripts/actions/install_kubectl.sh
+++ b/.scripts/actions/install_kubectl.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "$GITHUB_DEBUG" ] && set -x
+
+ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
+
+echo "::group::Install kubectl"
+curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+# Overwrite the existing binary
+sudo install -m 755 -t /usr/local/bin /tmp/kubectl
+
+kubectl version --client
+echo "::endgroup::"

--- a/.scripts/actions/install_kubectl_kuttl.sh
+++ b/.scripts/actions/install_kubectl_kuttl.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "$GITHUB_DEBUG" ] && set -x
+
+ARCH=$(uname -m)
+
+echo "::group::Install kubectl-kuttl"
+curl -fsSL -o /tmp/kubectl-kuttl "https://github.com/kudobuilder/kuttl/releases/download/v$KUTTL_VERSION/kubectl-kuttl_${KUTTL_VERSION}_linux_${ARCH}"
+sudo install -m 755 -t /usr/local/bin /tmp/kubectl-kuttl
+echo "::endgroup::"

--- a/.scripts/actions/install_stackablectl.sh
+++ b/.scripts/actions/install_stackablectl.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "$GITHUB_DEBUG" ] && set -x
+
+ARCH=$(uname -m)
+
+if [ "$STACKABLECTL_VERSION" == "latest" ]; then
+  curl -fsSL -o /tmp/stackablectl "https://github.com/stackabletech/stackable-cockpit/releases/latest/download/stackablectl-${ARCH}-unknown-linux-gnu"
+else
+  curl -fsSL -o /tmp/stackablectl "https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-${STACKABLECTL_VERSION}/stackablectl-${ARCH}-unknown-linux-gnu"
+fi
+
+sudo install -m 755 -t /usr/local/bin /tmp/stackablectl

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,5 @@
 To release a new set of actions follow these steps:
 
 - Choose an appropriate new semantic version based on the latest changes
-- Update any references in actions to other local actions to the chosen version
-- Raise a PR with the appropriate changes
-- Once merged, tag on `main` using `git tag -s v<X.Y.Z>`
+- Add a tag on `main` using `git tag -s v<X.Y.Z>`
 - Manually create a GitHub release

--- a/build-product-image/action.yaml
+++ b/build-product-image/action.yaml
@@ -42,11 +42,11 @@ runs:
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
     - name: Setup boil (${{ inputs.boil-version }})
-      # Using other "local" actions is super painful. As such, a follow-up PR will make this way
-      # more comfortable again.
-      uses: stackabletech/actions/setup-tools@main # TODO: Replace with latest released version
-      with:
-        boil-version: ${{ inputs.boil-version }}
+      env:
+        BOIL_VERSION: ${{ inputs.boil-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_boil.sh"
 
     - name: Building ${{ inputs.product-name }} Container Image using boil
       env:

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -34,13 +34,11 @@ runs:
       uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
     - name: Set up Helm
-      # We cannot use a path to point to the local action
-      # See https://github.com/orgs/community/discussions/74934
-      # Using other "local" actions is super painful. As such, a follow-up PR will make this way
-      # more comfortable again.
-      uses: stackabletech/actions/setup-k8s-tools@main # TODO: Replace with latest released version
-      with:
-        helm-version: ${{ inputs.helm-version }}
+      env:
+        HELM_VERSION: ${{ inputs.helm-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_helm.sh"
 
     - name: Log into Container Registry (${{ inputs.chart-registry-uri }}) using Helm
       env:

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -60,11 +60,12 @@ runs:
   using: composite
   steps:
     - name: Install interu
-      # Using other "local" actions is super painful. As such, a follow-up PR will make this way
-      # more comfortable again.
-      uses: stackabletech/actions/setup-tools@main # TODO: Replace with latest released version
-      with:
-        interu-version: ${{ inputs.interu-version }}
+      env:
+        INTERU_VERSION: ${{ inputs.interu-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_interu.sh"
+
     - name: Extract Test and Instance Configuration
       env:
         TEST_MODE_INPUT: ${{ inputs.test-mode-input }}
@@ -99,13 +100,16 @@ runs:
     # and are therefore not available, there is no need to create the cluster or run the tests,
     # because the tests can never run in the first place.
     - name: Install kubectl, kubectl-kuttl, and helm
-      # Using other "local" actions is super painful. As such, a follow-up PR will make this way
-      # more comfortable again.
-      uses: stackablectl/actions/setup-k8s-tools@main # TODO: Replace with latest released version
-      with:
-        kubectl-version: ${{ inputs.kubectl-version }}
-        kuttl-version: ${{ inputs.kuttl-version }}
-        helm-version: ${{ inputs.helm-version }}
+      env:
+        KUBECTL_VERSION: ${{ inputs.kubectl-version }}
+        KUTTL_VERSION: ${{ inputs.kuttl-version }}
+        HELM_VERSION: ${{ inputs.helm-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/../.scripts/actions/install_kubectl.sh"
+        "$GITHUB_ACTION_PATH/../.scripts/actions/install_kubectl_kuttl.sh"
+        "$GITHUB_ACTION_PATH/../.scripts/actions/install_helm.sh"
 
     # Python3 is already installed, if we ever need to specify the version, we can use the
     # setup-python action.
@@ -113,13 +117,24 @@ runs:
     #
     # mikefarah/yq is already installed on the runner
     # See https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-yq.sh
-    - name: Install stackablectl and beku
-      # Using other "local" actions is super painful. As such, a follow-up PR will make this way
-      # more comfortable again.
-      uses: stackabletech/actions/setup-tools@main # TODO: Replace with latest released version
-      with:
-        stackablectl-version: ${{ inputs.stackablectl-version }}
-        beku-version: ${{ inputs.beku-version }}
+    - name: Install stackablectl
+      env:
+        STACKABLECTL_VERSION: ${{ inputs.stackablectl-version }}
+        BEKU_VERSION: ${{ inputs.beku-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_stackablectl.sh"
+
+    - name: Install beku
+      env:
+        BEKU_VERSION: ${{ inputs.beku-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        [ -n "$GITHUB_DEBUG" ] && set -x
+
+        pip install "beku-stackabletech==$BEKU_VERSION"
 
     - name: Install apt packages
       shell: bash

--- a/setup-k8s-tools/action.yaml
+++ b/setup-k8s-tools/action.yaml
@@ -20,19 +20,7 @@ runs:
         KUBECTL_VERSION: ${{ inputs.kubectl-version }}
         GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
-      run: |
-        set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
-
-        ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
-
-        echo "::group::Install kubectl"
-        curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-        # Overwrite the existing binary
-        sudo install -m 755 -t /usr/local/bin /tmp/kubectl
-
-        kubectl version --client
-        echo "::endgroup::"
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_kubectl.sh"
 
     - name: Install kubectl-kuttl
       if: inputs.kuttl-version
@@ -40,14 +28,7 @@ runs:
         KUTTL_VERSION: ${{ inputs.kuttl-version }}
         GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
-      run: |
-        set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
-
-        echo "::group::Install kubectl-kuttl"
-        curl -fsSL -o /tmp/kubectl-kuttl "https://github.com/kudobuilder/kuttl/releases/download/v$KUTTL_VERSION/kubectl-kuttl_${KUTTL_VERSION}_linux_x86_64"
-        sudo install -m 755 -t /usr/local/bin /tmp/kubectl-kuttl
-        echo "::endgroup::"
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_kubectl_kuttl.sh"
 
     - name: Install Helm
       if: inputs.helm-version
@@ -55,26 +36,4 @@ runs:
         HELM_VERSION: ${{ inputs.helm-version }}
         GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
-      run: |
-        set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
-
-        PLATFORM=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_platform.sh")
-        ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
-
-        FILENAME="helm-${HELM_VERSION}-${PLATFORM}-${ARCH}.tar.gz"
-
-        echo "::group::Install helm"
-        mkdir /tmp/helm
-        curl -fsSL -o /tmp/helm/helm.tar.gz "https://get.helm.sh/${FILENAME}"
-        curl -fsSL -o /tmp/helm/helm.tar.gz.asc "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${FILENAME}.asc"
-
-        curl https://keybase.io/mattfarina/pgp_keys.asc | gpg --import
-        gpg --verify /tmp/helm/helm.tar.gz.asc /tmp/helm/helm.tar.gz
-
-        tar --directory="/tmp/helm" --strip-components=1 -zxvf /tmp/helm/helm.tar.gz "${PLATFORM}-${ARCH}"
-        # Overwrite the existing binary
-        sudo install -m 755 -t /usr/local/bin /tmp/helm/helm
-
-        helm version --short
-        echo "::endgroup::"
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_helm.sh"

--- a/setup-tools/action.yaml
+++ b/setup-tools/action.yaml
@@ -19,19 +19,7 @@ runs:
         BOIL_VERSION: ${{ inputs.boil-version }}
         GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
-      run: |
-        set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
-
-        ARCH=$(uname -m)
-
-        if [ "$BOIL_VERSION" == "latest" ]; then
-          curl -fsSL -o /tmp/boil "https://github.com/stackabletech/docker-images/releases/latest/download/boil-${ARCH}-unknown-linux-gnu"
-        else
-          curl -fsSL -o /tmp/boil "https://github.com/stackabletech/docker-images/releases/download/boil-${BOIL_VERSION}/boil-${ARCH}-unknown-linux-gnu"
-        fi
-
-        sudo install -m 755 -t /usr/local/bin /tmp/boil
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_boil.sh"
 
     - name: Install stackablectl
       if: inputs.stackablectl-version
@@ -39,19 +27,7 @@ runs:
         STACKABLECTL_VERSION: ${{ inputs.stackablectl-version }}
         GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
-      run: |
-        set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
-
-        ARCH=$(uname -m)
-
-        if [ "$STACKABLECTL_VERSION" == "latest" ]; then
-          curl -fsSL -o /tmp/stackablectl "https://github.com/stackabletech/stackable-cockpit/releases/latest/download/stackablectl-${ARCH}-unknown-linux-gnu"
-        else
-          curl -fsSL -o /tmp/stackablectl "https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-${STACKABLECTL_VERSION}/stackablectl-${ARCH}-unknown-linux-gnu"
-        fi
-
-        sudo install -m 755 -t /usr/local/bin /tmp/stackablectl
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_stackablectl.sh"
 
     - name: Install interu
       if: inputs.interu-version
@@ -59,19 +35,7 @@ runs:
         INTERU_VERSION: ${{ inputs.interu-version }}
         GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
-      run: |
-        set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
-
-        ARCH=$(uname -m)
-
-        if [ "$INTERU_VERSION" == "latest" ]; then
-          curl -fsSL -o /tmp/interu "https://github.com/stackabletech/actions/releases/latest/download/interu-${ARCH}-unknown-linux-gnu"
-        else
-          curl -fsSL -o /tmp/interu "https://github.com/stackabletech/actions/releases/download/interu-${INTERU_VERSION}/interu-${ARCH}-unknown-linux-gnu"
-        fi
-
-        sudo install -m 755 -t /usr/local/bin /tmp/interu
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_interu.sh"
 
     - name: Install beku
       if: inputs.beku-version

--- a/shard/action.yaml
+++ b/shard/action.yaml
@@ -15,11 +15,12 @@ outputs:
 runs:
   using: composite
   steps:
-    # Using other "local" actions is super painful. As such, a follow-up PR will make this way
-    # more comfortable again.
-    - uses: stackabletech/actions/setup-tools@main # TODO: Replace with latest released version
-      with:
-        boil-version: ${{ inputs.boil-version }}
+    - name: Setup boil (${{ inputs.boil-version }})
+      env:
+        BOIL_VERSION: ${{ inputs.boil-version }}
+        GITHUB_DEBUG: ${{ runner.debug }}
+      shell: bash
+      run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_boil.sh"
 
     - name: Generate Shards
       id: generate_shards


### PR DESCRIPTION
This allows us to abstract away the installation process into scripts which can be used by the two setup actions and other local actions. This removes the dependency on the setup actions for other local actions which would have been painful to manage going forward.