### PR TITLE
chore: Remove GITHUB_ENV usages

### DIFF
--- a/build-container-image/action.yaml
+++ b/build-container-image/action.yaml
@@ -63,7 +63,6 @@ runs:
         DOCKER_BUILD_ARGUMENTS=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_build_arguments.sh" "$BUILD_ARGUMENTS")
 
         IMAGE_ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
-        echo "IMAGE_ARCH=${IMAGE_ARCH}" | tee -a "$GITHUB_ENV"
 
         IMAGE_MANIFEST_TAG="${IMAGE_INDEX_MANIFEST_TAG}-${IMAGE_ARCH}"
         echo "IMAGE_MANIFEST_TAG=${IMAGE_MANIFEST_TAG}" | tee -a "$GITHUB_OUTPUT"

--- a/build-product-image/action.yaml
+++ b/build-product-image/action.yaml
@@ -29,12 +29,12 @@ outputs:
     description: |
       Human-readable tag (usually the version) with architecture information,
       for example: `3.4.1-stackable0.0.0-dev-amd64`
-    value: ${{ steps.image_info.outputs.IMAGE_MANIFEST_TAG }}
+    value: ${{ steps.build.outputs.IMAGE_MANIFEST_TAG }}
   suggested-image-index-manifest-tag:
     description: |
       Human-readable tag (usually the version) without architecture information,
       for example: `3.4.1-stackable0.0.0-dev`
-    value: ${{ steps.image_info.outputs.IMAGE_INDEX_MANIFEST_TAG }}
+    value: ${{ steps.build.outputs.IMAGE_INDEX_MANIFEST_TAG }}
 runs:
   using: composite
   steps:
@@ -49,6 +49,7 @@ runs:
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_boil.sh"
 
     - name: Building ${{ inputs.product-name }} Container Image using boil
+      id: build
       env:
         REGISTRY_NAMESPACE: ${{ inputs.registry-namespace }}
         BOIL_PRODUCT_VERSION: ${{ inputs.product-version }}
@@ -59,13 +60,14 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+
         IMAGE_ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
 
         # Will be either:
         # - 3.9.2-stackable0.0.0-dev or
         # - 3.9.2-stackable0.0.0-dev-pr321
         IMAGE_INDEX_MANIFEST_TAG="${SDP_VERSION}${EXTRA_TAG_DATA:+-$EXTRA_TAG_DATA}"
-        echo "IMAGE_INDEX_MANIFEST_TAG=$IMAGE_INDEX_MANIFEST_TAG" | tee -a "$GITHUB_ENV"
+        echo "IMAGE_INDEX_MANIFEST_TAG=$IMAGE_INDEX_MANIFEST_TAG" | tee -a "$GITHUB_OUTPUT"
 
         # Validate that final tag is valid according to
         # https://github.com/distribution/reference/blob/8c942b0459dfdcc5b6685581dd0a5a470f615bff/regexp.go#L68
@@ -82,26 +84,16 @@ runs:
           --configuration "$BOIL_CONFIG_FILE" \
           --write-image-manifest-uris \
           --use-localhost-registry \
-          --load \
-          "$IMAGE_REPOSITORY=$BOIL_PRODUCT_VERSION"
+          "$IMAGE_REPOSITORY=$BOIL_PRODUCT_VERSION" \
+          -- --load
         echo "::endgroup::"
 
-    - name: Extract Environment Variables
-      id: image_info
-      shell: bash
-      run: |
-        set -euo pipefail
         echo "boil-target-tags: "$(< boil-target-tags)
 
         # Extract the image manifest tag from the boil-target-tags file
         IMAGE_MANIFEST_TAG=$(cut -d : -f 2 < boil-target-tags)
         [[ -n "$IMAGE_MANIFEST_TAG" ]]
-        [[ -n "$IMAGE_INDEX_MANIFEST_TAG" ]]
-
-        # Add the contents of the env variables to the GitHub output, so that it
-        # can be used as action outputs
         echo "IMAGE_MANIFEST_TAG=$IMAGE_MANIFEST_TAG" | tee -a "$GITHUB_OUTPUT"
-        echo "IMAGE_INDEX_MANIFEST_TAG=$IMAGE_INDEX_MANIFEST_TAG" | tee -a "$GITHUB_OUTPUT"
 
     - name: Print out Disk Usage
       if: always()

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -76,6 +76,7 @@ runs:
         password: ${{ inputs.chart-registry-password }}
 
     - name: Package Helm Chart
+      id: package
       env:
         CHART_DIRECTORY: ${{ inputs.chart-directory }}
         CHART_VERSION: ${{ inputs.chart-version }}
@@ -92,7 +93,7 @@ runs:
 
         # Create temporary directory to store the Helm Chart
         TEMP_CHART_DIR=$(mktemp -d)
-        echo "TEMP_CHART_DIR=$TEMP_CHART_DIR" | tee -a "$GITHUB_ENV"
+        echo "TEMP_CHART_DIR=$TEMP_CHART_DIR" | tee -a "$GITHUB_OUTPUT"
 
         # Package the Helm Chart
         helm package \
@@ -102,8 +103,10 @@ runs:
           "$CHART_DIRECTORY"
 
     - name: Publish Helm Chart
+      id: publish
       if: inputs.publish-and-sign == 'true'
       env:
+        TEMP_CHART_DIR: ${{ steps.package.outputs.TEMP_CHART_DIR }}
         CHART_REGISTRY_URI: ${{ inputs.chart-registry-uri }}
         CHART_REPOSITORY: ${{ inputs.chart-repository }}
         CHART_DIRECTORY: ${{ inputs.chart-directory }}
@@ -116,7 +119,7 @@ runs:
 
         CHART_NAME=$(echo "$CHART_DIRECTORY" | awk -F/ '{print $NF}')
         CHART_ARTIFACT="${TEMP_CHART_DIR}/${CHART_NAME}-${CHART_VERSION}.tgz"
-        echo "CHART_NAME=$CHART_NAME" | tee -a "$GITHUB_ENV"
+        echo "CHART_NAME=$CHART_NAME" | tee -a "$GITHUB_OUTPUT"
 
         # Capture the stdout output to extract the digest. It is sad that Helm doesn't provide
         # structured output, eg. in JSON. There is a 2-year old open issue about it:
@@ -131,7 +134,7 @@ runs:
           exit 1
         fi
 
-        echo "CHART_DIGEST=$CHART_DIGEST" | tee -a "$GITHUB_ENV"
+        echo "CHART_DIGEST=$CHART_DIGEST" | tee -a "$GITHUB_OUTPUT"
 
     - name: Sign Helm Chart
       if: inputs.publish-and-sign == 'true'
@@ -139,7 +142,9 @@ runs:
         RETRY_TIMEOUT: ${{ inputs.cosign-retry-timeout }}
         RETRY_COUNT: ${{ inputs.cosign-retries }}
         RETRY_ARGS: --verbose
+        CHART_DIGEST: ${{ steps.publish.outputs.CHART_DIGEST }}
         CHART_REGISTRY_URI: ${{ inputs.chart-registry-uri }}
+        CHART_NAME: ${{ steps.publish.outputs.CHART_NAME }}
         CHART_REPOSITORY: ${{ inputs.chart-repository }}
         GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash

--- a/publish-image-index-manifest/action.yaml
+++ b/publish-image-index-manifest/action.yaml
@@ -103,7 +103,6 @@ runs:
         IMAGE_INDEX_URI: ${{ steps.create-index.outputs.IMAGE_INDEX_URI }}
         IMAGE_REPOSITORY: ${{ inputs.image-repository }}
         REGISTRY_URI: ${{ inputs.image-registry-uri }}
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
 

--- a/publish-image-index-manifest/action.yaml
+++ b/publish-image-index-manifest/action.yaml
@@ -54,14 +54,6 @@ runs:
         username: ${{ inputs.image-registry-username }}
         password: ${{ inputs.image-registry-password }}
 
-    - name: Extract Action Path
-      shell: bash
-      env:
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
-      run: |
-        set -euo pipefail
-        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH" | tee -a "$GITHUB_ENV"
-
     - name: Create Image Index Manifest Manifest
       id: create-index
       shell: bash
@@ -76,7 +68,6 @@ runs:
         # Construct the image index uri, which for example contains:
         # oci.stackable.tech/sdp/kafka:3.4.1-stackable0.0.0-dev
         IMAGE_INDEX_URI="$REGISTRY_URI/$IMAGE_REPOSITORY:$IMAGE_INDEX_MANIFEST_TAG"
-        echo "IMAGE_INDEX_URI=$IMAGE_INDEX_URI" | tee -a "$GITHUB_ENV"
         echo "IMAGE_INDEX_URI=$IMAGE_INDEX_URI" | tee -a "$GITHUB_OUTPUT"
 
         AMEND_OPTIONS=$(
@@ -109,8 +100,10 @@ runs:
         RETRY_TIMEOUT: ${{ inputs.cosign-retry-timeout }}
         RETRY_COUNT: ${{ inputs.cosign-retries }}
         RETRY_ARGS: --verbose
+        IMAGE_INDEX_URI: ${{ steps.create-index.outputs.IMAGE_INDEX_URI }}
         IMAGE_REPOSITORY: ${{ inputs.image-repository }}
         REGISTRY_URI: ${{ inputs.image-registry-uri }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
 

--- a/publish-image/action.yaml
+++ b/publish-image/action.yaml
@@ -67,15 +67,8 @@ runs:
         username: ${{ inputs.image-registry-username }}
         password: ${{ inputs.image-registry-password }}
 
-    - name: Extract Action Path
-      shell: bash
-      env:
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
-      run: |
-        set -euo pipefail
-        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH" | tee -a "$GITHUB_ENV"
-
     - name: Re-tag container image
+      id: re-tag
       shell: bash
       env:
         TARGET_IMAGE_URI: ${{ inputs.image-registry-uri }}/${{ inputs.image-repository }}:${{ inputs.image-manifest-tag }}
@@ -85,46 +78,54 @@ runs:
         docker tag "$SOURCE_IMAGE_URI" "$TARGET_IMAGE_URI"
 
         # Output for the next step
-        echo "IMAGE_MANIFEST_URI=$TARGET_IMAGE_URI" | tee -a "$GITHUB_ENV"
+        echo "IMAGE_MANIFEST_URI=$TARGET_IMAGE_URI" | tee -a "$GITHUB_OUTPUT"
 
     - name: Push the container image to ${{ inputs.image-registry-uri }}
+      id: push
       shell: bash
+      env:
+        IMAGE_MANIFEST_URI: ${{ steps.re-tag.outputs.IMAGE_MANIFEST_URI }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
         docker image push "$IMAGE_MANIFEST_URI"
 
         # Output for the next step
-        IMAGE_REPO_DIGEST=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_repo_digest.sh" "$IMAGE_MANIFEST_URI")
-        echo "IMAGE_REPO_DIGEST=$IMAGE_REPO_DIGEST" | tee -a "$GITHUB_ENV"
+        IMAGE_REPOSITORY_DIGEST=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_repo_digest.sh" "$IMAGE_MANIFEST_URI")
+        echo "IMAGE_REPOSITORY_DIGEST=$IMAGE_REPOSITORY_DIGEST" | tee -a "$GITHUB_OUTPUT"
 
-    - name: Sign the container image (${{ env.IMAGE_REPO_DIGEST }})
+    - name: Sign the container image (${{ env.IMAGE_REPOSITORY_DIGEST }})
       shell: bash
       env:
         RETRY_TIMEOUT: ${{ inputs.cosign-retry-timeout }}
         RETRY_COUNT: ${{ inputs.cosign-retries }}
         RETRY_ARGS: --verbose
+        IMAGE_REPOSITORY_DIGEST: ${{ steps.push.outputs.IMAGE_REPOSITORY_DIGEST }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
 
         # This generates a signature and publishes it to the registry, next to
         # the image. This step uses the keyless signing flow with Github Actions
         # as the identity provider.
-        "$GITHUB_ACTION_PATH/../.scripts/actions/retry.sh" cosign sign --yes "${IMAGE_REPO_DIGEST}"
+        "$GITHUB_ACTION_PATH/../.scripts/actions/retry.sh" cosign sign --yes "${IMAGE_REPOSITORY_DIGEST}"
 
-    - name: Generate SBOM for the container image (${{ env.IMAGE_REPO_DIGEST }})
+    - name: Generate SBOM for the container image (${{ env.IMAGE_REPOSITORY_DIGEST }})
       shell: bash
       env:
         RETRY_TIMEOUT: ${{ inputs.cosign-retry-timeout }}
         RETRY_COUNT: ${{ inputs.cosign-retries }}
         RETRY_ARGS: --verbose
+        IMAGE_REPOSITORY_DIGEST: ${{ steps.push.outputs.IMAGE_REPOSITORY_DIGEST }}
         IMAGE_MANIFEST_TAG: ${{ inputs.image-manifest-tag }}
         IMAGE_REPOSITORY: ${{ inputs.image-repository }}
         REGISTRY_URI: ${{ inputs.image-registry-uri }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
 
         # Extract the digest from the image repo digest (right side of '@')
-        DIGEST=${IMAGE_REPO_DIGEST#*@}
+        DIGEST=${IMAGE_REPOSITORY_DIGEST#*@}
 
         # URL encode the digest and image repository, needed for the purl
         URLENCODED_DIGEST=$(jq -rn --arg input "$DIGEST" '$input | @uri')
@@ -143,8 +144,8 @@ runs:
 
         # Get metadata from the image
         # NOTE (@Techassi): Maybe we should run this command only once
-        IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_REPO_DIGEST")
-        IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_REPO_DIGEST")
+        IMAGE_METADATA_DESCRIPTION=$(docker inspect --format='{{.Config.Labels.description}}' "$IMAGE_REPOSITORY_DIGEST")
+        IMAGE_METADATA_NAME=$(docker inspect --format='{{.Config.Labels.name}}' "$IMAGE_REPOSITORY_DIGEST")
 
         # Generate the SBOM
         syft scan \
@@ -152,7 +153,7 @@ runs:
           --select-catalogers "-cargo-auditable-binary-cataloger,+sbom-cataloger" \
           --scope all-layers \
           --source-name "$SOURCE_NAME" \
-          --source-version "$IMAGE_MANIFEST_TAG" "$IMAGE_REPO_DIGEST"
+          --source-version "$IMAGE_MANIFEST_TAG" "$IMAGE_REPOSITORY_DIGEST"
 
         # Merge SBOM components using https://github.com/stackabletech/mergebom
         curl --fail -L -o mergebom https://repo.stackable.tech/repository/packages/mergebom/stable-$(uname -m)
@@ -194,4 +195,4 @@ runs:
             --yes \
             --predicate sbom.merged.json \
             --type cyclonedx \
-            "${IMAGE_REPO_DIGEST}"
+            "${IMAGE_REPOSITORY_DIGEST}"

--- a/publish-image/action.yaml
+++ b/publish-image/action.yaml
@@ -85,7 +85,6 @@ runs:
       shell: bash
       env:
         IMAGE_MANIFEST_URI: ${{ steps.re-tag.outputs.IMAGE_MANIFEST_URI }}
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
         docker image push "$IMAGE_MANIFEST_URI"
@@ -101,7 +100,6 @@ runs:
         RETRY_COUNT: ${{ inputs.cosign-retries }}
         RETRY_ARGS: --verbose
         IMAGE_REPOSITORY_DIGEST: ${{ steps.push.outputs.IMAGE_REPOSITORY_DIGEST }}
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
 
@@ -120,7 +118,6 @@ runs:
         IMAGE_MANIFEST_TAG: ${{ inputs.image-manifest-tag }}
         IMAGE_REPOSITORY: ${{ inputs.image-repository }}
         REGISTRY_URI: ${{ inputs.image-registry-uri }}
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
 

--- a/run-pre-commit/action.yaml
+++ b/run-pre-commit/action.yaml
@@ -111,7 +111,7 @@ runs:
       shell: bash
       env:
         HADOLINT_VERSION: ${{ inputs.hadolint }}
-      run: | # zizmor: ignore[github-env] Using GITHUB_PATH is fine here, because the path is not user-controlled.
+      run: | # zizmor: ignore[github-env] Using GITHUB_PATH is fine here, because we set it to a known static path.
         set -euo pipefail
 
         LOCATION_DIR="$HOME/.local/bin"

--- a/run-pre-commit/action.yaml
+++ b/run-pre-commit/action.yaml
@@ -78,13 +78,14 @@ runs:
         key: pre-commit-${{ inputs.pre-commit-version }}-python${{ inputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Format Rust Toolchain Cache Key
+      id: rust-toolchain-cache-key
       if: ${{ inputs.rust }}
       shell: bash
       env:
         RUST_COMPONENTS: ${{ inputs.rust-components }}
       run: |
         RUST_COMPONENTS=${RUST_COMPONENTS//,/_}
-        echo "RUST_COMPONENTS=$RUST_COMPONENTS" | tee -a "$GITHUB_ENV"
+        echo "RUST_COMPONENTS=$RUST_COMPONENTS" | tee -a "$GITHUB_OUTPUT"
 
     - name: Setup Rust Toolchain Cache
       id: rust-toolchain-cache
@@ -92,7 +93,7 @@ runs:
       uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
       with:
         path: ~/.rustup/toolchains
-        key: rust-toolchains-${{ inputs.rust }}-components-${{ env.RUST_COMPONENTS }}
+        key: rust-toolchains-${{ inputs.rust }}-components-${{ steps.rust-toolchain-cache-key.outputs.RUST_COMPONENTS }}
 
     - name: Setup Rust Toolchain
       uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
@@ -110,7 +111,7 @@ runs:
       shell: bash
       env:
         HADOLINT_VERSION: ${{ inputs.hadolint }}
-      run: |
+      run: | # zizmor: ignore[github-env] Using GITHUB_PATH is fine here, because the path is not user-controlled.
         set -euo pipefail
 
         LOCATION_DIR="$HOME/.local/bin"

--- a/run-prek/action.yaml
+++ b/run-prek/action.yaml
@@ -62,13 +62,14 @@ runs:
         key: prek-${{ inputs.prek-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Format Rust Toolchain Cache Key
+      id: rust-toolchain-cache-key
       if: ${{ inputs.rust }}
       shell: bash
       env:
         RUST_COMPONENTS: ${{ inputs.rust-components }}
       run: |
         RUST_COMPONENTS=${RUST_COMPONENTS//,/_}
-        echo "RUST_COMPONENTS=$RUST_COMPONENTS" | tee -a "$GITHUB_ENV"
+        echo "RUST_COMPONENTS=$RUST_COMPONENTS" | tee -a "$GITHUB_OUTPUT"
 
     - name: Setup Rust Toolchain Cache
       id: rust-toolchain-cache
@@ -76,7 +77,7 @@ runs:
       uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
       with:
         path: ~/.rustup/toolchains
-        key: rust-toolchains-${{ inputs.rust }}-components-${{ env.RUST_COMPONENTS }}
+        key: rust-toolchains-${{ inputs.rust }}-components-${{ steps.rust-toolchain-cache-key.outputs.RUST_COMPONENTS }}
 
     - name: Setup Rust Toolchain
       uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
@@ -95,7 +96,7 @@ runs:
       shell: bash
       env:
         HADOLINT_VERSION: ${{ inputs.hadolint }}
-      run: |
+      run: | # zizmor: ignore[github-env] Using GITHUB_PATH is fine here, because the path is not user-controlled.
         set -euo pipefail
 
         LOCATION_DIR="$HOME/.local/bin"


### PR DESCRIPTION
This PR removes a whole bunch of `GITHUB_ENV` usages reported by SecObserve via zizmor.