### PR TITLE
feat: Make install scripts idempotent

### DIFF
--- a/.scripts/actions/install_boil.sh
+++ b/.scripts/actions/install_boil.sh
@@ -12,3 +12,4 @@ else
 fi
 
 sudo install -m 755 -t /usr/local/bin /tmp/boil
+rm -rf /tmp/boil

--- a/.scripts/actions/install_helm.sh
+++ b/.scripts/actions/install_helm.sh
@@ -22,6 +22,7 @@ fi
 tar --directory="/tmp/helm" --strip-components=1 -zxvf /tmp/helm/helm.tar.gz "${PLATFORM}-${ARCH}"
 # Overwrite the existing binary
 sudo install -m 755 -t /usr/local/bin /tmp/helm/helm
+rm -rf /tmp/helm
 
 helm version --short
 echo "::endgroup::"

--- a/.scripts/actions/install_interu.sh
+++ b/.scripts/actions/install_interu.sh
@@ -12,3 +12,4 @@ else
 fi
 
 sudo install -m 755 -t /usr/local/bin /tmp/interu
+rm -rf /tmp/interu

--- a/.scripts/actions/install_kubectl.sh
+++ b/.scripts/actions/install_kubectl.sh
@@ -9,6 +9,7 @@ echo "::group::Install kubectl"
 curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
 # Overwrite the existing binary
 sudo install -m 755 -t /usr/local/bin /tmp/kubectl
+rm -rf /tmp/kubectl
 
 kubectl version --client
 echo "::endgroup::"

--- a/.scripts/actions/install_kubectl_kuttl.sh
+++ b/.scripts/actions/install_kubectl_kuttl.sh
@@ -8,4 +8,5 @@ ARCH=$(uname -m)
 echo "::group::Install kubectl-kuttl"
 curl -fsSL -o /tmp/kubectl-kuttl "https://github.com/kudobuilder/kuttl/releases/download/v$KUTTL_VERSION/kubectl-kuttl_${KUTTL_VERSION}_linux_${ARCH}"
 sudo install -m 755 -t /usr/local/bin /tmp/kubectl-kuttl
+rm -rf /tmp/kubectl-kuttl
 echo "::endgroup::"

--- a/.scripts/actions/install_prek.sh
+++ b/.scripts/actions/install_prek.sh
@@ -17,6 +17,7 @@ fi
 
 tar --directory="/tmp/prek" --strip-components=1 -zxvf /tmp/prek/prek.tar.gz "prek-${ARCH}-unknown-linux-gnu/prek"
 sudo install -m 755 -t /usr/local/bin /tmp/prek/prek
+rm -rf /tmp/prek
 
 prek --version
 echo "::endgroup::"

--- a/.scripts/actions/install_stackablectl.sh
+++ b/.scripts/actions/install_stackablectl.sh
@@ -12,3 +12,4 @@ else
 fi
 
 sudo install -m 755 -t /usr/local/bin /tmp/stackablectl
+rm -rf /tmp/stackablectl


### PR DESCRIPTION
This PR adds an `rm -rf` to delete temporary files. This makes these install scripts idempotent when run multiple times in the same workflow.

In the future, we could do the smarter thing, which is to check if the requested version of a tool is already installed and then skipping re-installation altogether.