### PR TITLE
chore: Bump actions off Node.js 20

### DIFF
--- a/build-container-image/action.yaml
+++ b/build-container-image/action.yaml
@@ -40,7 +40,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Build ${{ inputs.image-name }}:${{ inputs.image-index-manifest-tag }}
       id: build-image

--- a/build-product-image/action.yaml
+++ b/build-product-image/action.yaml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Setup boil (${{ inputs.boil-version }})
       env:

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -75,7 +75,7 @@ runs:
 
     - name: Log into Container Registry (${{ inputs.chart-registry-uri }}) using Docker
       if: inputs.publish-and-sign == 'true'
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ inputs.chart-registry-uri }}
         username: ${{ inputs.chart-registry-username }}

--- a/publish-image-index-manifest/action.yaml
+++ b/publish-image-index-manifest/action.yaml
@@ -48,7 +48,7 @@ runs:
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ inputs.image-registry-uri }}
         username: ${{ inputs.image-registry-username }}

--- a/publish-image/action.yaml
+++ b/publish-image/action.yaml
@@ -58,10 +58,10 @@ runs:
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
     - name: Set up syft
-      uses: anchore/sbom-action/download-syft@0b82b0b1a22399a1c542d4d656f70cd903571b5c # v0.21.1
+      uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
-      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ inputs.image-registry-uri }}
         username: ${{ inputs.image-registry-username }}

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -146,7 +146,7 @@ runs:
 
     - name: Prepare Replicated Cluster
       id: prepare-replicated-cluster
-      uses: replicatedhq/replicated-actions/create-cluster@49b440dabd7e0e868cbbabda5cfc0d8332a279fa # v1.19.0
+      uses: replicatedhq/replicated-actions/create-cluster@291bef61a059631e39e84f8470f86152171c4c20 # v1.26.0
       with:
         # See: https://github.com/replicatedhq/replicated-actions/tree/main/create-cluster#inputs
         api-token: ${{ inputs.replicated-api-token }}
@@ -256,7 +256,7 @@ runs:
       if: always()
       # If the creation of the cluster failed, we don't want to error and abort
       continue-on-error: true
-      uses: replicatedhq/replicated-actions/remove-cluster@49b440dabd7e0e868cbbabda5cfc0d8332a279fa # v1.19.0
+      uses: replicatedhq/replicated-actions/remove-cluster@291bef61a059631e39e84f8470f86152171c4c20 # v1.26.0
       with:
         # See: https://github.com/replicatedhq/replicated-actions/tree/main/remove-cluster#inputs
         api-token: ${{ inputs.replicated-api-token }}

--- a/run-pre-commit/action.yaml
+++ b/run-pre-commit/action.yaml
@@ -104,7 +104,7 @@ runs:
 
     - name: Setup Rust Cache
       if: ${{ inputs.rust }}
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
     - name: Install Hadolint
       if: ${{ inputs.hadolint }}

--- a/run-prek/action.yaml
+++ b/run-prek/action.yaml
@@ -88,7 +88,7 @@ runs:
 
     - name: Setup Rust Cache
       if: ${{ inputs.rust }}
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
     # TODO (@Techassi): Move this into a script
     - name: Install Hadolint

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -137,7 +137,7 @@ runs:
 
     - name: Send Notification
       id: send-notification
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # 2.1.1
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       with:
         method: chat.postMessage
         token: ${{ inputs.slack-token }}


### PR DESCRIPTION
We'll soon be affected by this (see the warnings in [this PR run](https://github.com/stackabletech/docker-images/actions/runs/26222422201/job/77160580606#annotation:13:2) for example):
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: anchore/sbom-action/download-syft@0b82b0b1a22399a1c542d4d656f70cd903571b5c, docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef, docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

This PR bumps three actions to get off Node.js 20 before the GitHub Actions runner deprecation:

- `docker/login-action` v3.6.0 -> v4.1.0
- `docker/setup-buildx-action` v3.12.0 -> v4.0.0
- `anchore/sbom-action/download-syft` v0.21.1 -> v0.24.0
- `Swatinem/rust-cache` v2.8.2 -> v2.9.1
- `slackapi/slack-github-action` v2.1.1 -> v3.0.3
- `replicatedhq/replicated-actions/{create,remove}-cluster` v1.19.0 -> v1.26.0

All three releases switch the runtime to Node.js 24.

I checked the changelogs for breaking changes (also Syft changelog), didn't spot anything that would affect us.