### PR TITLE
feat(publish-helm-chart): Split helm stdout/stderr

### DIFF
--- a/.github/workflows/smoke-build.yaml
+++ b/.github/workflows/smoke-build.yaml
@@ -118,13 +118,24 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Package, Publish, and Sign Helm Chart
+      - name: Package, Publish, and Sign Helm Chart (oci.stackable.tech)
         uses: ./publish-helm-chart
         with:
           chart-registry-uri: oci.stackable.tech
           chart-registry-username: robot$smoke+github-action-build
           chart-registry-password: ${{ secrets.HARBOR_ROBOT_SMOKE_GITHUB_ACTION_BUILD_SECRET }}
           chart-repository: smoke
+          chart-directory: smoke/helm-chart
+          chart-version: ${{ matrix.versions }}
+          app-version: ${{ matrix.versions }}
+
+      - name: Package, Publish, and Sign Helm Chart (quay.io)
+        uses: ./publish-helm-chart
+        with:
+          chart-registry-uri: quay.io
+          chart-registry-username: stackable+robot_sdp_charts_github_action_build
+          chart-registry-password: ${{ secrets.QUAY_ROBOT_SDP_CHARTS_GITHUB_ACTION_BUILD_SECRET }}
+          chart-repository: stackable/smoke
           chart-directory: smoke/helm-chart
           chart-version: ${{ matrix.versions }}
           app-version: ${{ matrix.versions }}

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -149,7 +149,9 @@ runs:
         # HELM_OUTPUT=$(helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2>&1)
         helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2> helm.stderr 1> helm.stdout
 
+        echo "stdout"
         cat helm.stdout
+        echo "stderr"
         cat helm.stderr
 
         if [ $? -ne 0 ]; then

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -148,13 +148,14 @@ runs:
         # https://github.com/helm/helm/issues/11735
         # Helm outputs the digest on STDERR, for whatever ridiculous reason. Like, who makes these
         # decisions?
+        set +e
         HELM_OUTPUT=$(helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2>&1)
-
         if [ $? -ne 0 ]; then
           echo "Helm push command failed"
           echo "$HELM_OUTPUT"
           exit 1
         fi
+        set -e
 
         # Yuck
         CHART_DIGEST=$(echo "$HELM_OUTPUT" | awk '/^Digest: sha256:[0-9a-f]{64}$/ { print $2 }')

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -146,10 +146,17 @@ runs:
         # Capture the stdout output to extract the digest. It is sad that Helm doesn't provide
         # structured output, eg. in JSON. There is a 2-year old open issue about it:
         # https://github.com/helm/helm/issues/11735
-        HELM_OUTPUT=$(helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2>&1)
+        # HELM_OUTPUT=$(helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2>&1)
+        helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2> helm.stderr 1> helm.stdout
+
+        if [ $? -ne 0 ]; then
+          echo "helm push command failed"
+          cat helm.stderr
+          exit 1
+        fi
 
         # Yuck
-        CHART_DIGEST=$(echo "$HELM_OUTPUT" | awk '/^Digest: sha256:[0-9a-f]{64}$/ { print $2 }')
+        CHART_DIGEST=$(cat helm.stdout | awk '/^Digest: sha256:[0-9a-f]{64}$/ { print $2 }')
 
         if [ -z "$CHART_DIGEST" ]; then
           echo "Could not find digest of Helm Chart"

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -157,7 +157,7 @@ runs:
         fi
 
         # Yuck
-        CHART_DIGEST=$(cat helm.stdout | awk '/^Digest: sha256:[0-9a-f]{64}$/ { print $2 }')
+        CHART_DIGEST=$(cat "$HELM_OUTPUT" | awk '/^Digest: sha256:[0-9a-f]{64}$/ { print $2 }')
 
         if [ -z "$CHART_DIGEST" ]; then
           echo "Could not find digest of Helm Chart"

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -157,7 +157,7 @@ runs:
         fi
 
         # Yuck
-        CHART_DIGEST=$(cat "$HELM_OUTPUT" | awk '/^Digest: sha256:[0-9a-f]{64}$/ { print $2 }')
+        CHART_DIGEST=$(echo "$HELM_OUTPUT" | awk '/^Digest: sha256:[0-9a-f]{64}$/ { print $2 }')
 
         if [ -z "$CHART_DIGEST" ]; then
           echo "Could not find digest of Helm Chart"

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -149,6 +149,9 @@ runs:
         # HELM_OUTPUT=$(helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2>&1)
         helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2> helm.stderr 1> helm.stdout
 
+        cat helm.stdout
+        cat helm.stderr
+
         if [ $? -ne 0 ]; then
           echo "helm push command failed"
           cat helm.stderr

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -146,17 +146,13 @@ runs:
         # Capture the stdout output to extract the digest. It is sad that Helm doesn't provide
         # structured output, eg. in JSON. There is a 2-year old open issue about it:
         # https://github.com/helm/helm/issues/11735
-        # HELM_OUTPUT=$(helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2>&1)
-        helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2> helm.stderr 1> helm.stdout
-
-        echo "stdout"
-        cat helm.stdout
-        echo "stderr"
-        cat helm.stderr
+        # Helm outputs the digest on STDERR, for whatever ridiculous reason. Like, who makes these
+        # decisions?
+        HELM_OUTPUT=$(helm push "$CHART_ARTIFACT" "oci://${CHART_REGISTRY_URI}/${CHART_REPOSITORY}" 2>&1)
 
         if [ $? -ne 0 ]; then
-          echo "helm push command failed"
-          cat helm.stderr
+          echo "Helm push command failed"
+          echo "$HELM_OUTPUT"
           exit 1
         fi
 


### PR DESCRIPTION
This should help diagnosing push failures, like those encountered when rolling out https://github.com/stackabletech/operator-templating/pull/584.