### PR TITLE
chore(publish-helm-chart): Bump default Helm version to 3.21.1

### DIFF
--- a/committed.toml
+++ b/committed.toml
@@ -1,3 +1,4 @@
+subject_length = 65
 style = "conventional"
 allowed_types = ["refactor", "chore", "feat", "docs", "fix", "ci"]
 # Generated using `cargo boil image list --pretty never | jq 'keys'` + boil, patchable

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -17,7 +17,7 @@ inputs:
   helm-version:
     description: Version of helm
     # See https://github.com/helm/helm/releases for latest version
-    default: v3.19.0
+    default: v3.21.1
   chart-version:
     description: The Helm Chart version
     required: true


### PR DESCRIPTION
Basically what it says on the tin.