### PR TITLE
chore: Use RUNNER_DEBUG env var directly

### DIFF
--- a/.scripts/actions/install_boil.sh
+++ b/.scripts/actions/install_boil.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-[ -n "$GITHUB_DEBUG" ] && set -x
+[ -n "${RUNNER_DEBUG+set}" ] && set -x
 
 ARCH=$(uname -m)
 

--- a/.scripts/actions/install_helm.sh
+++ b/.scripts/actions/install_helm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-[ -n "$GITHUB_DEBUG" ] && set -x
+[ -n "${RUNNER_DEBUG+set}" ] && set -x
 
 PLATFORM=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_platform.sh")
 ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")

--- a/.scripts/actions/install_interu.sh
+++ b/.scripts/actions/install_interu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-[ -n "$GITHUB_DEBUG" ] && set -x
+[ -n "${RUNNER_DEBUG+set}" ] && set -x
 
 ARCH=$(uname -m)
 

--- a/.scripts/actions/install_kubectl.sh
+++ b/.scripts/actions/install_kubectl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-[ -n "$GITHUB_DEBUG" ] && set -x
+[ -n "${RUNNER_DEBUG+set}" ] && set -x
 
 ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
 

--- a/.scripts/actions/install_kubectl_kuttl.sh
+++ b/.scripts/actions/install_kubectl_kuttl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-[ -n "$GITHUB_DEBUG" ] && set -x
+[ -n "${RUNNER_DEBUG+set}" ] && set -x
 
 ARCH=$(uname -m)
 

--- a/.scripts/actions/install_prek.sh
+++ b/.scripts/actions/install_prek.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-[ -n "$GITHUB_DEBUG" ] && set -x
+[ -n "${RUNNER_DEBUG+set}" ] && set -x
 
 ARCH=$(uname -m)
 

--- a/.scripts/actions/install_stackablectl.sh
+++ b/.scripts/actions/install_stackablectl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-[ -n "$GITHUB_DEBUG" ] && set -x
+[ -n "${RUNNER_DEBUG+set}" ] && set -x
 
 ARCH=$(uname -m)
 

--- a/build-product-image/action.yaml
+++ b/build-product-image/action.yaml
@@ -44,7 +44,6 @@ runs:
     - name: Setup boil (${{ inputs.boil-version }})
       env:
         BOIL_VERSION: ${{ inputs.boil-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_boil.sh"
 
@@ -60,6 +59,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         IMAGE_ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
 

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -54,7 +54,6 @@ runs:
     - name: Set up Helm
       env:
         HELM_VERSION: ${{ inputs.helm-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
         VERIFY_SIGNATURE: "false"
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_helm.sh"
@@ -65,11 +64,10 @@ runs:
         CHART_REGISTRY_USERNAME: ${{ inputs.chart-registry-username }}
         CHART_REGISTRY_PASSWORD: ${{ inputs.chart-registry-password }}
         CHART_REGISTRY_URI: ${{ inputs.chart-registry-uri }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         helm registry login --username "$CHART_REGISTRY_USERNAME" --password "$CHART_REGISTRY_PASSWORD" "$CHART_REGISTRY_URI"
 
@@ -86,11 +84,10 @@ runs:
       env:
         CHART_REGISTRY_URI: ${{ inputs.chart-registry-uri }}
         CHART_DIRECTORY: ${{ inputs.chart-directory }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         # This is directly taken from the official yq examples and merges all
         # listed files. ORDER MATTERS. Later files are merged into earlier files.
@@ -107,11 +104,10 @@ runs:
         CHART_DIRECTORY: ${{ inputs.chart-directory }}
         CHART_VERSION: ${{ inputs.chart-version }}
         APP_VERSION: ${{ inputs.app-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         # Create temporary directory to store the Helm Chart
         TEMP_CHART_DIR=$(mktemp -d)
@@ -133,11 +129,10 @@ runs:
         CHART_REPOSITORY: ${{ inputs.chart-repository }}
         CHART_DIRECTORY: ${{ inputs.chart-directory }}
         CHART_VERSION: ${{ inputs.chart-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         CHART_NAME=$(echo "$CHART_DIRECTORY" | awk -F/ '{print $NF}')
         CHART_ARTIFACT="${TEMP_CHART_DIR}/${CHART_NAME}-${CHART_VERSION}.tgz"
@@ -168,11 +163,10 @@ runs:
         CHART_REGISTRY_URI: ${{ inputs.chart-registry-uri }}
         CHART_NAME: ${{ steps.publish.outputs.CHART_NAME }}
         CHART_REPOSITORY: ${{ inputs.chart-repository }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         # This generates a signature and publishes it to the registry, next to the chart artifact
         # Uses the keyless signing flow with Github Actions as identity provider

--- a/run-integration-test/action.yaml
+++ b/run-integration-test/action.yaml
@@ -62,7 +62,7 @@ runs:
     - name: Install interu
       env:
         INTERU_VERSION: ${{ inputs.interu-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
+        RUNNER_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_interu.sh"
 
@@ -72,13 +72,13 @@ runs:
         TEST_SUITE: ${{ inputs.test-suite }}
         TEST_MODE: ${{ inputs.test-mode }}
         TEST: ${{ inputs.test }}
-        GITHUB_DEBUG: ${{ runner.debug }}
+        RUNNER_DEBUG: ${{ runner.debug }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_RUN_ID: ${{ github.run_id }}"
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         # Generate the cluster name
         echo "KUBERNETES_CLUSTER_NAME=integration-test-${GITHUB_REPOSITORY}-${GITHUB_RUN_ID}" | tee -a "$GITHUB_ENV"
@@ -104,7 +104,7 @@ runs:
         KUBECTL_VERSION: ${{ inputs.kubectl-version }}
         KUTTL_VERSION: ${{ inputs.kuttl-version }}
         HELM_VERSION: ${{ inputs.helm-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
+        RUNNER_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         "$GITHUB_ACTION_PATH/../.scripts/actions/install_kubectl.sh"
@@ -120,18 +120,16 @@ runs:
     - name: Install stackablectl
       env:
         STACKABLECTL_VERSION: ${{ inputs.stackablectl-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_stackablectl.sh"
 
     - name: Install beku
       env:
         BEKU_VERSION: ${{ inputs.beku-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         pip install "beku-stackabletech==$BEKU_VERSION"
 
@@ -170,6 +168,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+
         mkdir ~/.kube
         echo "$KUBECONFIG" > ~/.kube/config
 

--- a/run-openshift-preflight/action.yaml
+++ b/run-openshift-preflight/action.yaml
@@ -19,11 +19,10 @@ runs:
     - name: Download the OpenShift preflight tool
       env:
         PREFLIGHT_VERSION: ${{ inputs.preflight-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         ARCH=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_architecture.sh")
         SYSTEM=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_platform.sh")
@@ -40,21 +39,18 @@ runs:
       env:
         IMAGE_ARCHITECTURE: ${{ inputs.image-architecture }}
         IMAGE_INDEX_URI: ${{ inputs.image-index-uri }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         openshift-preflight check container "$IMAGE_INDEX_URI" --platform "$IMAGE_ARCHITECTURE" > preflight.out
 
     - name: Report Result
-      env:
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         if [ "$(jq -r .passed < preflight.out)" == true ]; then
           echo "Checks Passed"

--- a/run-prek/action.yaml
+++ b/run-prek/action.yaml
@@ -50,7 +50,6 @@ runs:
       shell: bash
       env:
         PREK_VERSION: ${{ inputs.prek-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_prek.sh"
 
       # This caches downloaded prek hook artifacts and results in faster

--- a/setup-k8s-tools/action.yaml
+++ b/setup-k8s-tools/action.yaml
@@ -18,7 +18,6 @@ runs:
       if: inputs.kubectl-version
       env:
         KUBECTL_VERSION: ${{ inputs.kubectl-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_kubectl.sh"
 
@@ -26,7 +25,6 @@ runs:
       if: inputs.kuttl-version
       env:
         KUTTL_VERSION: ${{ inputs.kuttl-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_kubectl_kuttl.sh"
 
@@ -34,7 +32,6 @@ runs:
       if: inputs.helm-version
       env:
         HELM_VERSION: ${{ inputs.helm-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
         # The signature is expired since a couple of years...
         VERIFY_SIGNATURE: "false"
       shell: bash

--- a/setup-tools/action.yaml
+++ b/setup-tools/action.yaml
@@ -17,7 +17,6 @@ runs:
       if: inputs.boil-version
       env:
         BOIL_VERSION: ${{ inputs.boil-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_boil.sh"
 
@@ -25,7 +24,6 @@ runs:
       if: inputs.stackablectl-version
       env:
         STACKABLECTL_VERSION: ${{ inputs.stackablectl-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_stackablectl.sh"
 
@@ -33,7 +31,6 @@ runs:
       if: inputs.interu-version
       env:
         INTERU_VERSION: ${{ inputs.interu-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_interu.sh"
 
@@ -41,10 +38,9 @@ runs:
       if: inputs.beku-version
       env:
         BEKU_VERSION: ${{ inputs.beku-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         pip install "beku-stackabletech==$BEKU_VERSION"

--- a/shard/action.yaml
+++ b/shard/action.yaml
@@ -19,7 +19,6 @@ runs:
     - name: Setup boil (${{ inputs.boil-version }})
       env:
         BOIL_VERSION: ${{ inputs.boil-version }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: "$GITHUB_ACTION_PATH/../.scripts/actions/install_boil.sh"
 
@@ -27,22 +26,20 @@ runs:
       id: generate_shards
       env:
         PRODUCT_NAME: ${{ inputs.product-name }}
-        GITHUB_DEBUG: ${{ runner.debug }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         VERSIONS=$(boil image list "$PRODUCT_NAME" | jq --compact-output --arg product_name "$PRODUCT_NAME" '.[$product_name]')
         echo "VERSIONS=$VERSIONS" | tee -a "$GITHUB_OUTPUT"
 
     - name: Print Shards
       env:
-        GITHUB_DEBUG: ${{ runner.debug }}
         VERSIONS: ${{ steps.generate_shards.outputs.VERSIONS }}
       shell: bash
       run: |
         set -euo pipefail
-        [ -n "$GITHUB_DEBUG" ] && set -x
+        [ -n "${RUNNER_DEBUG+set}" ] && set -x
 
         echo "versions=$VERSIONS"


### PR DESCRIPTION
Instead of assigning `${{ runner.debug }}` to `GITHUB_DEBUG`, use `RUNNER_DEBUG` directly.