### PR TITLE
chore: Bump actions

### DIFF
--- a/.github/workflows/build_interu.yml
+++ b/.github/workflows/build_interu.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: ${{ inputs.target }}
@@ -44,6 +44,6 @@ jobs:
 
       - name: Upload Artifact
         if: inputs.upload
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: interu-${{ inputs.target }}

--- a/.github/workflows/pr_prek.yml
+++ b/.github/workflows/pr_prek.yml
@@ -10,7 +10,7 @@ jobs:
   prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/pr_title-check.yaml
+++ b/.github/workflows/pr_title-check.yaml
@@ -11,7 +11,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/release_interu.yml
+++ b/.github/workflows/release_interu.yml
@@ -29,11 +29,11 @@ jobs:
       contents: write
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
       - name: Upload Release Binary
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: artifacts/artifact/*

--- a/.github/workflows/smoke-build.yaml
+++ b/.github/workflows/smoke-build.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Generate Version List
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -50,7 +50,7 @@ jobs:
         versions: ${{ fromJson(needs.generate-matrix.outputs.versions) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -89,7 +89,7 @@ jobs:
         versions: ${{ fromJson(needs.generate-matrix.outputs.versions) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -113,7 +113,7 @@ jobs:
         versions: ${{ fromJson(needs.generate-matrix.outputs.versions) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -140,7 +140,7 @@ jobs:
     if: failure() || github.run_attempt > 1
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/build-container-image/action.yaml
+++ b/build-container-image/action.yaml
@@ -40,7 +40,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Build ${{ inputs.image-name }}:${{ inputs.image-index-manifest-tag }}
       id: build-image

--- a/build-product-image/action.yaml
+++ b/build-product-image/action.yaml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Setup boil (${{ inputs.boil-version }})
       env:

--- a/publish-helm-chart/action.yaml
+++ b/publish-helm-chart/action.yaml
@@ -49,7 +49,7 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Set up Helm
       env:
@@ -73,7 +73,7 @@ runs:
 
     - name: Log into Container Registry (${{ inputs.chart-registry-uri }}) using Docker
       if: inputs.publish-and-sign == 'true'
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.chart-registry-uri }}
         username: ${{ inputs.chart-registry-username }}

--- a/publish-image-index-manifest/action.yaml
+++ b/publish-image-index-manifest/action.yaml
@@ -45,10 +45,10 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.image-registry-uri }}
         username: ${{ inputs.image-registry-username }}

--- a/publish-image/action.yaml
+++ b/publish-image/action.yaml
@@ -55,13 +55,13 @@ runs:
   using: composite
   steps:
     - name: Set up Cosign
-      uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Set up syft
       uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
     - name: Login to Container Registry (${{ inputs.image-registry-uri }})
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ inputs.image-registry-uri }}
         username: ${{ inputs.image-registry-username }}

--- a/run-pre-commit/action.yaml
+++ b/run-pre-commit/action.yaml
@@ -42,13 +42,13 @@ runs:
 
     - name: Setup nix
       if: inputs.nix
-      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
       with:
         github_access_token: ${{ inputs.nix-github-token }}
         install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix }}/install
 
     - name: Setup Python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
         # It doesn't make a whole lot of sense to use the pre-commit config file
@@ -72,7 +72,7 @@ runs:
       # This caches downloaded pre-commit hook artifacts and results in faster
       # workflow runs after an initial hydration run with the exact same hooks
     - name: Setup pre-commit Cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ inputs.pre-commit-version }}-python${{ inputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -90,13 +90,13 @@ runs:
     - name: Setup Rust Toolchain Cache
       id: rust-toolchain-cache
       if: ${{ inputs.rust }}
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.rustup/toolchains
         key: rust-toolchains-${{ inputs.rust }}-components-${{ steps.rust-toolchain-cache-key.outputs.RUST_COMPONENTS }}
 
     - name: Setup Rust Toolchain
-      uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       if: ${{ inputs.rust && steps.rust-toolchain-cache.outputs.cache-hit != 'true' }}
       with:
         toolchain: ${{ inputs.rust }}
@@ -104,7 +104,7 @@ runs:
 
     - name: Setup Rust Cache
       if: ${{ inputs.rust }}
-      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
     - name: Install Hadolint
       if: ${{ inputs.hadolint }}

--- a/run-prek/action.yaml
+++ b/run-prek/action.yaml
@@ -41,7 +41,7 @@ runs:
 
     - name: Setup nix
       if: inputs.nix
-      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
       with:
         github_access_token: ${{ inputs.nix-github-token }}
         install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix }}/install
@@ -55,7 +55,7 @@ runs:
       # This caches downloaded prek hook artifacts and results in faster
       # workflow runs after an initial hydration run with the exact same hooks
     - name: Setup prek Cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/prek
         key: prek-${{ inputs.prek-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -73,13 +73,13 @@ runs:
     - name: Setup Rust Toolchain Cache
       id: rust-toolchain-cache
       if: ${{ inputs.rust }}
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.rustup/toolchains
         key: rust-toolchains-${{ inputs.rust }}-components-${{ steps.rust-toolchain-cache-key.outputs.RUST_COMPONENTS }}
 
     - name: Setup Rust Toolchain
-      uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       if: ${{ inputs.rust && steps.rust-toolchain-cache.outputs.cache-hit != 'true' }}
       with:
         toolchain: ${{ inputs.rust }}
@@ -87,7 +87,7 @@ runs:
 
     - name: Setup Rust Cache
       if: ${{ inputs.rust }}
-      uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
     # TODO (@Techassi): Move this into a script
     - name: Install Hadolint

--- a/send-slack-notification/action.yaml
+++ b/send-slack-notification/action.yaml
@@ -72,7 +72,7 @@ runs:
     - name: Retrieve Slack Thread ID
       id: retrieve-slack-thread-id
       continue-on-error: true
-      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: slack-thread-id-${{ github.run_id }}
 
@@ -154,7 +154,7 @@ runs:
 
     - name: Store Slack Thread ID as Artifact
       if: steps.retrieve-slack-thread-id.outcome == 'failure'
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: slack-thread-id-${{ github.run_id }}
         path: slack-thread-id


### PR DESCRIPTION
This PR bumps actions in CI and upstream actions used in our own actions.

- Bump `actions/checkout` from `v6.0.1` to `v7.0.0`
- Bump `actions/upload-artifact` from `v6.0.0` to `v7.0.1`
- Bump `actions/download-artifact` from `v7.0.0` to `v8.0.1`
- Bump `softprops/action-gh-release` from `v2.5.0` to `v3.0.0`
- Bump `docker/setup-buildx-action` from `v4.0.0` to `v4.3.0`
- Bump `sigstore/cosign-installer` from `v4.0.0` to `v4.1.2`
  This new version includes download retries, which is nice, because GitHub is flaky af these days and I observed download failures a bunch of times already.
- Bump `docker/login-action` from `v4.1.0` to `v4.2.0`
- Bump `cachix/install-nix-action` from `v31.9.0` to `v31.10.6`
- Bump `actions/setup-python` from `v6.1.0` to `v6.2.0`
- Bump `actions/cache` from `v5.0.1` to `v5.0.5`
- Bump `dtolnay/rust-toolchain`

bb86a79 mentions us using a commit for `Swatinem/rust-cache` which doesn't exist upstream. This needs further investigation.