### PR TITLE
feat(publish-image-index-manifest): Expose image index manifest digest

### DIFF
--- a/publish-image-index-manifest/README.md
+++ b/publish-image-index-manifest/README.md
@@ -29,5 +29,6 @@ This action creates an image index manifest, publishes it, and signs it. It does
 ### Outputs
 
 - `image-index-uri`: The final image index URI, eg. `oci.stackable.tech/spd/kafka:3.4.1-stackable0.0.0-dev`.
+- `image-index-manifest-digest`: The digest (`sha256:...`) of the pushed image index manifest, used as input for SLSA provenance generation.
 
 [publish-image-index-manifest]: ./action.yaml

--- a/publish-image-index-manifest/action.yaml
+++ b/publish-image-index-manifest/action.yaml
@@ -41,6 +41,11 @@ outputs:
   image-index-uri:
     description: The Image Index URI.
     value: ${{ steps.create-index.outputs.IMAGE_INDEX_URI }}
+  image-index-manifest-digest:
+    description: |
+      The digest (sha256:...) of the pushed image index manifest. Used as input
+      for SLSA provenance generation.
+    value: ${{ steps.create-index.outputs.IMAGE_INDEX_MANIFEST_DIGEST }}
 runs:
   using: composite
   steps:
@@ -94,6 +99,11 @@ runs:
         docker manifest create "$IMAGE_INDEX_URI" ${AMEND_OPTIONS[@]}
         docker manifest push "$IMAGE_INDEX_URI"
 
+        # Get the image index manifest digest and expose it as an output, so it
+        # can be fed into SLSA provenance generation.
+        DIGEST=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_manifest_digest.sh" "$IMAGE_INDEX_URI")
+        echo "IMAGE_INDEX_MANIFEST_DIGEST=$DIGEST" | tee -a "$GITHUB_OUTPUT"
+
     - name: Sign Image Index Manifest
       shell: bash
       env:
@@ -101,13 +111,11 @@ runs:
         RETRY_COUNT: ${{ inputs.cosign-retries }}
         RETRY_ARGS: --verbose
         IMAGE_INDEX_URI: ${{ steps.create-index.outputs.IMAGE_INDEX_URI }}
+        DIGEST: ${{ steps.create-index.outputs.IMAGE_INDEX_MANIFEST_DIGEST }}
         IMAGE_REPOSITORY: ${{ inputs.image-repository }}
         REGISTRY_URI: ${{ inputs.image-registry-uri }}
       run: |
         set -euo pipefail
-
-        # Get the image index manifest digest
-        DIGEST=$("$GITHUB_ACTION_PATH/../.scripts/actions/get_manifest_digest.sh" "$IMAGE_INDEX_URI")
 
         # Construct the image repo digest, which for example contains:
         # oci.stackable.tech/sdp/kafka@sha256:91...


### PR DESCRIPTION
This is needed to generate [SLSA](https://slsa.dev/) provenance for our images (= signed attestations attached to an image / index manifest that prove when and how the image was built).

Add an `image-index-manifest-digest` output to the publish-image-index-manifest action so the digest of the pushed multi-arch index can be fed into SLSA provenance generation.

The digest is now computed right after `docker manifest push` in the create-index step and reused by the sign step instead of being recomputed.

Optional extra information:
I added SLSA provenance to our fork of SecObserve already in a similar fashion, here is the workflow run:
https://github.com/stackabletech/SecObserve/actions/runs/28184881580

Here is an example of how to manually inspect the SLSA provenance attestation for an image:
```
cosign download attestation oci.stackable.tech/stackable/secobserve-backend@sha256:f86020f9a9cc94e9481c94920b46acbf141f809928f6ade07a59
de8a844526f3 | jq -r '.payload' | base64 -d | jq 'select(.predicateType=="https://slsa.dev/provenance/v0.2") | .predicate.invocation'
```

Or using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier):
```
slsa-verifier verify-image oci.stackable.tech/stackable/secobserve-backend@sha256:f86020f9a9cc94e9481c94920b46acbf141f809928f6ade07a59de8a844526f3 --source-uri github.com/stackabletech/SecObserve
```

It's basically a signed JSON document that provides a ton of metadata about the image build. The attestation is done by an isolated job that runs `https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/workflows/generator_container_slsa3.yml`, so it's an independent "witness" that can't be manipulated (this means we achieve [SLSA level 3](https://slsa.dev/spec/v0.1/levels)). Luckily it's pretty easy to do since we use GitHub actions.