### PR TITLE
feat(publish-image): Attest SPDX SBOM alongside CycloneDX

### DIFF
--- a/publish-image/README.md
+++ b/publish-image/README.md
@@ -9,9 +9,10 @@ following work:
    `image-repository`.
 2. Push the container image to the specified registry.
 3. Sign the container image (which pushes the signature to the specified registry).
-4. Generate an SBOM via a syft scan.
-5. Attest an image with the SBOM as a predicate (which pushes the attestation to the specified
-   registry).
+4. Generate a CycloneDX SBOM via a syft scan and merge its components.
+5. Convert the merged CycloneDX SBOM to SPDX (normalising deprecated license ids).
+6. Attest the image with both the CycloneDX and SPDX SBOMs as predicates (which pushes the
+   attestations to the specified registry).
 
 ## Inputs and Outputs
 

--- a/publish-image/action.yaml
+++ b/publish-image/action.yaml
@@ -193,3 +193,25 @@ runs:
             --predicate sbom.merged.json \
             --type cyclonedx \
             "${IMAGE_REPOSITORY_DIGEST}"
+
+        # Derive an SPDX SBOM from the merged CycloneDX SBOM. We only generate
+        # CycloneDX, SPDX is produced by conversion so both formats describe the
+        # same merged, deduplicated inventory.
+        syft convert sbom.merged.json --output spdx-json=sbom.spdx.raw.json
+
+        # Normalise deprecated SPDX license identifiers that strict validators and
+        # some consumers reject. syft still emits the deprecated standalone form
+        # "GPL-2.0-with-classpath-exception"; rewrite it to the valid WITH
+        # expression. Extend the `fix` chain if further deprecated ids show up.
+        jq '
+          def fix: gsub("GPL-2.0-with-classpath-exception"; "GPL-2.0-only WITH Classpath-exception-2.0");
+          (.. | .licenseDeclared?  // empty) |= (if type == "string" then fix else . end)
+        | (.. | .licenseConcluded? // empty) |= (if type == "string" then fix else . end)
+        ' sbom.spdx.raw.json > sbom.spdx.json
+
+        # Attest the SPDX SBOM to the image
+        "$GITHUB_ACTION_PATH/../.scripts/actions/retry.sh" cosign attest \
+            --yes \
+            --predicate sbom.spdx.json \
+            --type spdxjson \
+            "${IMAGE_REPOSITORY_DIGEST}"


### PR DESCRIPTION
We currently only generate and attest CycloneDX SBOMs, but some consumers expect SPDX. This PR derives an SPDX SBOM from the existing merged CycloneDX SBOM and attests it to the image as a second predicate, so every image we publish carries both formats.

Rather than generating SPDX independently, the merged CycloneDX SBOM is converted with `syft convert`. This keeps both formats describing the same merged, deduplicated inventory (the mergebom output, including the reconstructed JAR dependency graph and the `rhel` -> `redhat` rename).
Known issue: File-level entries are dropped by the conversion, package and dependency information is preserved. That is fine as the file-level information is totally optional anyway, SPDX still includes all the necessary information.

One extra step was needed: syft still emits the deprecated SPDX license id `GPL-2.0-with-classpath-exception`, which strict SPDX validators reject. We rewrite it to the valid `GPL-2.0-only WITH Classpath-exception-2.0` expression with `jq`. With that, the converted SPDX validates cleanly ([pyspdxtools](https://github.com/spdx/tools-python) exits 0, while without it, exit 1 with 33+ errors).